### PR TITLE
Update-1.0027-from-14-04-2026 (Blog: Shipments model + journal/filters/breadcrumbs; Outgoing mail date validation)

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -15,7 +15,6 @@ from django.forms.models import BaseInlineFormSet
 from django.forms import ValidationError
 from django.contrib.contenttypes.admin import GenericTabularInline
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet
-
 from crm.models import (
     Notifications,
     Customer,
@@ -88,6 +87,8 @@ from .models import (
     Attachment,
     UniversalRKD,
     RKDDeveloper,
+    Shipment,
+    ShipmentAdditionalFile,
 )
 from .services import WorkAssignmentService
 
@@ -234,6 +235,27 @@ class UniversalRKDInline(admin.TabularInline):
     )
 
 
+class ShipmentAdditionalFileInline(admin.TabularInline):
+    model = ShipmentAdditionalFile
+    extra = 1
+    fields = ("file",)
+
+
+class ShipmentInline(admin.TabularInline):
+    model = Shipment
+    extra = 0
+    show_change_link = True
+    fields = (
+        "serial_number",
+        "manufacture_date",
+        "product_passport",
+        "shipment_date",
+        "recipient",
+        "note",
+    )
+    autocomplete_fields = ("recipient",)
+
+
 @admin.register(Post)
 class PostAdmin(admin.ModelAdmin):
     change_form_template = "admin/blog/universal_rkd_category_change_form.html"
@@ -253,6 +275,7 @@ class PostAdmin(admin.ModelAdmin):
         RevisionTaskInline,
         WorkAssignmentInline,
         UniversalRKDInline,
+        ShipmentInline,
     ]
 
     def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
@@ -264,10 +287,18 @@ class PostAdmin(admin.ModelAdmin):
         for instance in instances:
             instance.post = form.instance
 
-            # Если name пустое или только пробелы — взять из головной модели
-            if not instance.name or not instance.name.strip():
-                instance.name = instance.post.name
+            # Только для сущностей с полем name (журнал РКД и др.)
+            if hasattr(instance, "name"):
+                if not instance.name or not instance.name.strip():
+                    instance.name = instance.post.name
 
+            if isinstance(instance, Shipment):
+                user = request.user
+                if instance.pk is None:
+                    instance.author = user
+                instance.last_editor = user
+                if not instance.current_responsible_id:
+                    instance.current_responsible = user
 
             instance.save()
         formset.save_m2m()
@@ -516,6 +547,134 @@ class UniversalRKDAdmin(admin.ModelAdmin):
         if not change:
             obj.author = request.user
         obj.last_editor = request.user
+        super().save_model(request, obj, form, change)
+
+
+@admin.register(Shipment)
+class ShipmentAdmin(admin.ModelAdmin):
+    """Журнал: только 7 колонок по ТЗ (без id и прочих служебных в списке)."""
+
+    change_list_template = "admin/blog/shipment/change_list.html"
+    inlines = (ShipmentAdditionalFileInline,)
+    list_display = (
+        "serial_number",
+        "manufacture_date",
+        "passport_link",
+        "additional_files_links",
+        "shipment_date",
+        "recipient",
+        "note",
+    )
+    list_display_links = ("serial_number",)
+    list_filter = ("post",)
+    search_fields = ("serial_number", "post__name", "note", "completeness")
+    ordering = ("post", "manufacture_date", "serial_number", "pk")
+    autocomplete_fields = (
+        "post",
+        "recipient",
+        "author",
+        "last_editor",
+        "current_responsible",
+    )
+    fieldsets = (
+        (
+            "Разработка",
+            {"fields": ("post",)},
+        ),
+        (
+            "Данные отгрузки",
+            {
+                "fields": (
+                    "serial_number",
+                    "manufacture_date",
+                    "product_passport",
+                    "shipment_date",
+                    "recipient",
+                    "completeness",
+                    "note",
+                )
+            },
+        ),
+        (
+            "Ответственные",
+            {
+                "fields": (
+                    "author",
+                    "last_editor",
+                    "current_responsible",
+                    "date_of_creation",
+                    "date_of_change",
+                )
+            },
+        ),
+    )
+
+    def get_queryset(self, request):
+        return (
+            super()
+            .get_queryset(request)
+            .select_related("post", "recipient")
+            .prefetch_related("additional_files")
+        )
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = dict(extra_context or {})
+        post_id = request.GET.get("post__id__exact")
+        if post_id:
+            extra_context["shipment_breadcrumb_post"] = Post.objects.filter(pk=post_id).first()
+        return super().changelist_view(request, extra_context)
+
+    def get_readonly_fields(self, request, obj=None):
+        """Создатель фиксируется при первом сохранении; в уже созданной записи только просмотр."""
+        fields = ["date_of_creation", "date_of_change"]
+        if obj is not None:
+            fields.append("author")
+        return fields
+
+    def get_changeform_initial_data(self, request):
+        initial = super().get_changeform_initial_data(request)
+        initial = dict(initial or {})
+        initial["author"] = request.user.pk
+        initial["last_editor"] = request.user.pk
+        initial["current_responsible"] = request.user.pk
+        return initial
+
+    @admin.display(description="Паспорт", ordering="product_passport")
+    def passport_link(self, obj):
+        if obj.product_passport:
+            return format_html(
+                '<a href="{}" target="_blank" rel="noopener noreferrer">Открыть файл</a>',
+                obj.product_passport.url,
+            )
+        return "—"
+
+    @admin.display(description="Дополнительные данные (загружаемый файл)")
+    def additional_files_links(self, obj):
+        rows = list(obj.additional_files.all())
+        if not rows:
+            return "—"
+        parts = []
+        for af in rows:
+            f = getattr(af, "file", None)
+            if f and getattr(f, "name", None):
+                name = f.name.rsplit("/", 1)[-1]
+                parts.append(
+                    format_html(
+                        '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>',
+                        f.url,
+                        escape(name),
+                    )
+                )
+        if not parts:
+            return "—"
+        return mark_safe("<br>".join(str(p) for p in parts))
+
+    def save_model(self, request, obj, form, change):
+        if not change:
+            obj.author = request.user
+        obj.last_editor = request.user
+        if not obj.current_responsible_id:
+            obj.current_responsible = request.user
         super().save_model(request, obj, form, change)
 
 
@@ -1309,6 +1468,18 @@ class OutgoingLetterAdmin(admin.ModelAdmin):
             from datetime import time, datetime
             dt = datetime.combine(d, t or time(0, 0))
             cleaned["date_of_send"] = timezone.make_aware(dt, timezone.get_current_timezone())
+
+            letter_date = cleaned.get("letter_date")
+            if letter_date is not None and cleaned.get("date_of_send"):
+                send_local_date = timezone.localtime(cleaned["date_of_send"]).date()
+                if send_local_date < letter_date:
+                    raise ValidationError(
+                        {
+                            "date_of_send_date": (
+                                "Дата отправки не может быть раньше даты письма."
+                            ),
+                        }
+                    )
 
             recipient = cleaned.get("recipient")
             person_recipient = cleaned.get("person_recipient")

--- a/blog/models.py
+++ b/blog/models.py
@@ -1965,3 +1965,151 @@ class UniversalRKD(models.Model):
             max_o = agg["m"] or 0
             self.order_in_section = max_o + 1
         super().save(*args, **kwargs)
+
+
+class Shipment(models.Model):
+    """Отгрузки изделий в рамках разработки (модификации)."""
+
+    post = models.ForeignKey(
+        "Post",
+        on_delete=models.CASCADE,
+        related_name="shipments",
+        verbose_name="Разработка (модификация)",
+    )
+    serial_number = models.CharField(max_length=20, verbose_name="Заводской номер")
+    manufacture_date = models.DateField(verbose_name="Дата изготовления")
+    product_passport = models.FileField(
+        upload_to="blog/shipment/passport/%Y/%m/",
+        blank=True,
+        null=True,
+        verbose_name="Паспорт",
+    )
+    shipment_date = models.DateField(
+        null=True,
+        blank=True,
+        verbose_name="Дата отгрузки",
+    )
+    recipient = models.ForeignKey(
+        "crm.Customer",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="shipments",
+        verbose_name="Получатель",
+    )
+    completeness = models.TextField(
+        max_length=5000,
+        blank=True,
+        default="",
+        verbose_name="Комплектность",
+    )
+    note = models.TextField(
+        max_length=1000,
+        blank=True,
+        default="",
+        verbose_name="Примечание",
+    )
+    author = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="shipments_created",
+        verbose_name="Создатель",
+    )
+    date_of_creation = models.DateTimeField(
+        default=timezone.now,
+        verbose_name="Дата и время создания",
+    )
+    last_editor = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="shipments_edited",
+        verbose_name="Последний редактор",
+    )
+    date_of_change = models.DateTimeField(
+        auto_now=True,
+        verbose_name="Дата и время последнего изменения",
+    )
+    current_responsible = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="shipments_responsible",
+        verbose_name="Текущий ответственный",
+    )
+
+    class Meta:
+        verbose_name = "Отгрузка"
+        verbose_name_plural = "Отгрузки"
+        ordering = ("post", "manufacture_date", "serial_number", "pk")
+        constraints = [
+            models.UniqueConstraint(
+                fields=("post", "serial_number"),
+                name="blog_shipment_unique_serial_per_post",
+            ),
+        ]
+
+    def __str__(self):
+        return f"{self.serial_number} — {self.post}"
+
+    def clean(self):
+        super().clean()
+        if self.serial_number is not None:
+            self.serial_number = self.serial_number.strip()
+
+        if self.post_id and self.serial_number:
+            qs = Shipment.objects.filter(
+                post_id=self.post_id,
+                serial_number=self.serial_number,
+            )
+            if self.pk:
+                qs = qs.exclude(pk=self.pk)
+            if qs.exists():
+                p = Post.objects.filter(pk=self.post_id).only("name").first()
+                post_title = p.name if p else "—"
+                raise ValidationError(
+                    {
+                        "serial_number": (
+                            f"В отгрузке по разработке «{post_title}» такой заводской номер уже существует."
+                        ),
+                    }
+                )
+
+        if (
+            self.shipment_date
+            and self.manufacture_date
+            and self.shipment_date < self.manufacture_date
+        ):
+            raise ValidationError(
+                {
+                    "shipment_date": (
+                        "Дата отгрузки не может быть раньше даты изготовления."
+                    ),
+                }
+            )
+
+
+class ShipmentAdditionalFile(models.Model):
+    """Дополнительные файлы к отгрузке (несколько штук)."""
+
+    shipment = models.ForeignKey(
+        Shipment,
+        on_delete=models.CASCADE,
+        related_name="additional_files",
+        verbose_name="Отгрузка",
+    )
+    file = models.FileField(
+        upload_to="blog/shipment/additional/%Y/%m/",
+        verbose_name="Файл",
+    )
+
+    class Meta:
+        verbose_name = "Дополнительный файл отгрузки"
+        verbose_name_plural = "Дополнительные файлы отгрузки"
+
+    def __str__(self):
+        return self.file.name if self.file else str(self.pk)

--- a/shared_repository/models.py
+++ b/shared_repository/models.py
@@ -852,7 +852,9 @@ class AdministrativeOrder(models.Model):
         settings.AUTH_USER_MODEL,
         on_delete=models.PROTECT,
         related_name='authored_orders',
-        verbose_name='Создатель (автор)'
+        verbose_name='Создатель (автор)',
+        null=True,
+        blank=True
     )
     date_of_creation = models.DateTimeField(
         verbose_name='Дата и время создания',
@@ -862,7 +864,9 @@ class AdministrativeOrder(models.Model):
         settings.AUTH_USER_MODEL,
         on_delete=models.PROTECT,
         related_name='edited_orders',
-        verbose_name='Последний редактор'
+        verbose_name='Последний редактор',
+        null=True,
+        blank=True
     )
     date_of_change = models.DateTimeField(
         verbose_name='Дата и время последнего изменения',
@@ -872,7 +876,9 @@ class AdministrativeOrder(models.Model):
         settings.AUTH_USER_MODEL,
         on_delete=models.PROTECT,
         related_name='responsible_orders',
-        verbose_name='Текущий ответственный'
+        verbose_name='Текущий ответственный',
+        null=True,
+        blank=True
     )
     version = models.CharField(
         max_length=3,

--- a/templates/admin/blog/shipment/change_list.html
+++ b/templates/admin/blog/shipment/change_list.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=cl.opts.app_label %}">{{ cl.opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url cl.opts|admin_urlname:'changelist' %}">{{ cl.opts.verbose_name_plural|capfirst }}</a>
+{% if shipment_breadcrumb_post %}
+&rsaquo; {{ shipment_breadcrumb_post.name }}
+{% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Blog: shipments (model, inline on Post, changelist with Post filter/sort and breadcrumbs when filtered, unique factory number check), optional passport/extra files; outgoing letters — send date not before letter date.
