### PR TITLE
Update-1.0031-from-04-05-2026 (Blog: ProductGroup, Post, WorkAssignment, Shipment)

### DIFF
--- a/blog/admin.py
+++ b/blog/admin.py
@@ -1,14 +1,17 @@
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.admin.utils import unquote
+from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
 from django.shortcuts import redirect, render
 from django.urls import path, reverse
 from django.utils import timezone
 from datetime import timedelta
 from django.utils.html import escape, format_html
+from django.template.defaultfilters import linebreaksbr
 from django.utils.safestring import mark_safe
 import re
-from django.db.models import Q, F, Value, TextField, DateField, BooleanField, Case, When
+from django.db.models import Q, F, Value , TextField, DateField, BooleanField, Case, When, IntegerField
+from django.db.models.functions import Cast
 from functools import reduce
 from operator import and_, or_
 from django.forms.models import BaseInlineFormSet
@@ -48,7 +51,7 @@ KnowledgeBase, KnowledgeBaseFile, QMSDocument,QMSDocumentAcceptSignature, Admini
 AdministrativeOrderAcceptSignature, DocumentTemplate, DocumentTemplateAcceptSignature)
 
 from .admin_forms import RescheduleAdminForm
-from .forms import WorkAssignmentForm, UniversalRKDForm
+from .forms import WorkAssignmentForm, UniversalRKDForm, TechnicalProposalForm
 from .helpers import (
     first_incomplete_step_code,
     next_step_code_after,
@@ -74,22 +77,25 @@ from .models import (
     ListTechnicalProposal,
     Post,
     Process,
+    ProductGroup,
+    ProductGroupDocument,
     ProtocolTechnicalProposal,
     ReportTechnicalProposal,
     Route,
     RouteProcess,
     SoftwareProduct,
-    TechnicalProposal,
+    TechnicalProposalDocument,
     TaskForDesignWork,
     RevisionTask,
     WorkAssignment,
+    WorkAssignmentSubtask,
     WorkAssignmentDeadlineChange,
     Attachment,
     UniversalRKD,
     RKDDeveloper,
+    RKDDeveloperAdditionalFile,
     Shipment,
     ShipmentAdditionalFile,
-    ShipmentSupplier,
 )
 from .services import WorkAssignmentService
 
@@ -103,7 +109,6 @@ def _inject_rkd_category_json(extra_context):
 
 
 def _admin_warning_triangle_html(*, title: str, color: str = "#f0ad4e") -> str:
-    """Как в журнале СИЗ / поверки: жёлтый треугольник с подсказкой."""
     t = escape(title)
     return (
         f'<span title="{t}" style="display:inline-flex;align-items:center;">'
@@ -117,12 +122,14 @@ def _admin_warning_triangle_html(*, title: str, color: str = "#f0ad4e") -> str:
     )
 
 
-def _universal_rkd_planned_review_show_warning(validity_date) -> bool:
-    """Предупреждение, если до даты пересмотра осталось не более 60 дней или срок уже прошёл."""
+def _universal_rkd_planned_review_show_warning(validity_date, *, days: int) -> bool:
     if not validity_date:
         return False
+    d = int(days or 0)
+    if d < 0:
+        d = 0
     today = timezone.now().date()
-    return (validity_date - today).days <= 60
+    return (validity_date - today).days <= d
 
 
 class RequiredFileGenericFormSet(BaseGenericInlineFormSet):
@@ -156,14 +163,341 @@ class RequiredFileGenericFormSet(BaseGenericInlineFormSet):
 
 class AttachmentInline(GenericTabularInline):
     model = Attachment
-    formset = RequiredFileGenericFormSet   # ваш общий formset
+    formset = RequiredFileGenericFormSet
     extra = 1
     fields = ("file",)
 
-@admin.register(TechnicalProposal)
-class TechnicalProposalAdmin(admin.ModelAdmin):
-    list_display = ['name', 'author', 'date_of_creation']
-    readonly_fields = ('date_of_creation', 'date_of_change')
+
+class WorkAssignmentAttachmentInline(AttachmentInline):
+    verbose_name_plural = "Вложения"
+
+
+def _tp_docs_section_header(title: str):
+    return mark_safe(
+        '<div style="'
+        "margin: 0 0 10px 0;"
+        "padding: 10px 14px;"
+        "font-weight: 700;"
+        "font-size: 13px;"
+        "letter-spacing: 0.4px;"
+        "text-transform: uppercase;"
+        "border-left: 4px solid var(--primary, #79aec8);"
+        "background: var(--darkened-bg, rgba(121,174,200,0.12));"
+        "color: var(--body-fg, inherit);"
+        "border-radius: 3px;"
+        f'">{escape(title)}</div>'
+    )
+
+
+@admin.register(TechnicalProposalDocument)
+class TechnicalProposalDocumentAdmin(admin.ModelAdmin):
+    change_form_template = "admin/blog/technicalproposaldocument/change_form.html"
+    change_list_template = "admin/blog/technicalproposaldocument/change_list.html"
+    form = TechnicalProposalForm
+
+    list_display = (
+        "tp_post_column",
+        "tp_document_kind",
+        "category",
+        "desig_document",
+        "name",
+        "tp_documents_column",
+        "status",
+    )
+    list_display_links = ("name",)
+    list_filter = ("document_kind", "status", "post")
+    search_fields = ("name", "desig_document", "category", "post__name")
+
+    @admin.display(description="Разработка (модификация)", ordering="post")
+    def tp_post_column(self, obj):
+        return obj.post or "—"
+
+    @admin.display(description="Вид документа ПТ", ordering="document_kind")
+    def tp_document_kind(self, obj):
+        return obj.get_document_kind_display() or "—"
+
+    @admin.display(description="Документ")
+    def tp_documents_column(self, obj):
+        parts = []
+        if obj.document_uploaded_file:
+            parts.append(
+                format_html(
+                    '<a href="{}" target="_blank" rel="noopener noreferrer">Документ</a>',
+                    obj.document_uploaded_file.url,
+                )
+            )
+        if obj.approval_document:
+            parts.append(
+                format_html(
+                    '<a href="{}" target="_blank" rel="noopener noreferrer">Лист утверждения</a>',
+                    obj.approval_document.url,
+                )
+            )
+        if obj.attestation_document:
+            parts.append(
+                format_html(
+                    '<a href="{}" target="_blank" rel="noopener noreferrer">Удостоверяющий лист</a>',
+                    obj.attestation_document.url,
+                )
+            )
+        if not parts:
+            return "—"
+        return mark_safe("<br>".join(str(p) for p in parts))
+
+    autocomplete_fields = (
+        "post",
+        "author",
+        "last_editor",
+        "current_responsible",
+        "checked_by",
+        "approved_by",
+        "develop_org",
+    )
+    readonly_fields = (
+        "date_of_creation",
+        "date_of_change",
+        "tp_display_files_list",
+    )
+
+    fieldsets = (
+        (
+            "Разработка и классификация",
+            {
+                "fields": (
+                    "post",
+                    "document_kind",
+                    "category",
+                    "name",
+                    "desig_document",
+                    "litera",
+                    "trl",
+                )
+            },
+        ),
+        (
+            "Содержание и статус",
+            {
+                "fields": (
+                    "info_format",
+                    "status",
+                    "related_documents",
+                    "develop_org",
+                )
+            },
+        ),
+        (
+            None,
+            {
+                "description": _tp_docs_section_header("Основной документ"),
+                "fields": (
+                    "document_uploaded_file",
+                    "document_source",
+                ),
+            },
+        ),
+        (
+            None,
+            {
+                "description": _tp_docs_section_header("Лист утверждения"),
+                "fields": (
+                    "approval_document",
+                    "approval_source",
+                ),
+            },
+        ),
+        (
+            None,
+            {
+                "description": _tp_docs_section_header("Удостоверяющий лист"),
+                "fields": (
+                    "attestation_document",
+                    "attestation_source",
+                ),
+            },
+        ),
+        (
+            "Согласование",
+            {
+                "fields": (
+                    "checked_by",
+                    "signature_checked",
+                    "approved_by",
+                    "signature_approved",
+                )
+            },
+        ),
+        (
+            "Дополнительно",
+            {
+                "fields": (
+                    "comment",
+                )
+            },
+        ),
+        (
+            "Ответственные",
+            {
+                "fields": (
+                    "author",
+                    "current_responsible",
+                    "last_editor",
+                    "version",
+                    "date_of_creation",
+                    "date_of_change",
+                )
+            },
+        ),
+        (
+            "Файлы документа",
+            {
+                "fields": ("tp_display_files_list",),
+            },
+        ),
+    )
+
+    @admin.display(description="Файлы документа")
+    def tp_display_files_list(self, obj):
+        card_style = (
+            "border: 1px solid var(--hairline-color, #e1e4e8);"
+            "border-radius: 6px;"
+            "background: var(--body-bg, #fff);"
+            "padding: 14px 16px;"
+            "max-width: 920px;"
+        )
+        section_title = (
+            "margin: 16px 0 8px 0;"
+            "font-size: 12px;"
+            "font-weight: 600;"
+            "letter-spacing: 0.02em;"
+            "text-transform: uppercase;"
+            "color: var(--body-quiet-color, #6b7280);"
+        )
+        row_base = "display:flex; gap:12px; align-items:flex-start; padding:8px 0;"
+        row_sep = "border-bottom: 1px solid var(--hairline-color, #eef0f3);"
+        label_style = "width: 260px; flex: 0 0 260px; color: var(--body-fg, #111); font-weight: 500;"
+        value_style = "flex: 1; min-width: 0; word-break: break-word;"
+        muted = "color: var(--body-quiet-color, #6b7280);"
+        link_style = "color: var(--link-fg, #417690); text-decoration: none;"
+
+        if not obj or not getattr(obj, "pk", None):
+            return format_html(
+                '<div style="{}">'
+                '<div style="{}">Сводка по файлам</div>'
+                '<div style="{}">После первого сохранения записи здесь появятся ссылки на загруженные файлы.</div>'
+                "</div>",
+                card_style,
+                section_title,
+                muted,
+            )
+
+        def _basename(f):
+            name = getattr(f, "name", "") or ""
+            return name.rsplit("/", 1)[-1] or name
+
+        def _row(label, f, *, with_sep, uploaded_by=None, uploaded_at=None):
+            row_style = row_base + (row_sep if with_sep else "")
+            label_html = f'<div style="{label_style}">{escape(label)}</div>'
+            if not f:
+                return f'<div style="{row_style}">{label_html}<div style="{value_style} {muted}">не загружен</div></div>'
+            url = getattr(f, "url", "") or ""
+            filename = escape(_basename(f))
+            if url:
+                value = f'<a href="{escape(url)}" target="_blank" rel="noopener noreferrer" style="{link_style}">{filename}</a>'
+            else:
+                value = f'<span style="{muted}">{filename}</span>'
+            if uploaded_by and uploaded_at:
+                value += (
+                    f'<div style="margin-top:6px;font-size:12px;{muted}">'
+                    f"изменил: {escape(uploaded_by.get_username())} · "
+                    f"{escape(uploaded_at.strftime('%d.%m.%Y %H:%M'))}"
+                    f"</div>"
+                )
+            elif uploaded_by:
+                value += (
+                    f'<div style="margin-top:6px;font-size:12px;{muted}">'
+                    f"изменил: {escape(uploaded_by.get_username())}"
+                    f"</div>"
+                )
+            return f'<div style="{row_style}">{label_html}<div style="{value_style}">{value}</div></div>'
+
+        last_editor = getattr(obj, "last_editor", None) or getattr(obj, "author", None)
+        changed_at = getattr(obj, "date_of_change", None)
+
+        html = f'<div style="{card_style}">'
+        html += f'<div style="{section_title}">Документы</div>'
+        html += _row("Документ — итоговый", getattr(obj, "document_uploaded_file", None), with_sep=True, uploaded_by=last_editor, uploaded_at=changed_at)
+        html += _row("Документ — исходник", getattr(obj, "document_source", None), with_sep=True, uploaded_by=last_editor, uploaded_at=changed_at)
+        html += _row("Лист утверждения — итоговый (PDF)", getattr(obj, "approval_document", None), with_sep=True, uploaded_by=last_editor, uploaded_at=changed_at)
+        html += _row("Лист утверждения — исходник (DOCX)", getattr(obj, "approval_source", None), with_sep=True, uploaded_by=last_editor, uploaded_at=changed_at)
+        html += _row("Удостоверяющий лист — итоговый (PDF)", getattr(obj, "attestation_document", None), with_sep=True, uploaded_by=last_editor, uploaded_at=changed_at)
+        html += _row("Удостоверяющий лист — исходник (DOCX)", getattr(obj, "attestation_source", None), with_sep=False, uploaded_by=last_editor, uploaded_at=changed_at)
+        html += f'<div style="{section_title}">Подписи</div>'
+        html += _row("Подпись проверки", getattr(obj, "signature_checked", None), with_sep=True, uploaded_by=last_editor, uploaded_at=changed_at)
+        html += _row("Подпись утверждения", getattr(obj, "signature_approved", None), with_sep=False, uploaded_by=last_editor, uploaded_at=changed_at)
+        html += "</div>"
+        return mark_safe(html)
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related(
+            "post",
+            "develop_org",
+            "author",
+            "last_editor",
+            "current_responsible",
+            "checked_by",
+            "approved_by",
+        )
+
+    def changelist_view(self, request, extra_context=None):
+        extra_context = dict(extra_context or {})
+        post_id = request.GET.get("post__id__exact")
+        if post_id:
+            extra_context["tp_breadcrumb_post"] = Post.objects.filter(pk=post_id).first()
+        return super().changelist_view(request, extra_context)
+
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        extra_context = dict(extra_context or {})
+        if object_id:
+            obj = self.get_object(request, unquote(object_id))
+            if obj is not None:
+                if obj.post_id:
+                    extra_context["tp_breadcrumb_post"] = obj.post
+                extra_context["tp_breadcrumb_record_title"] = str(obj)
+        else:
+            post_q = request.GET.get("post")
+            if post_q:
+                extra_context["tp_breadcrumb_post"] = Post.objects.filter(pk=post_q).first()
+        return super().changeform_view(request, object_id, form_url, extra_context)
+
+    def save_model(self, request, obj, form, change):
+        if not change:
+            obj.author = request.user
+        obj.last_editor = request.user
+        super().save_model(request, obj, form, change)
+
+    _PDF_FILE_FIELDS = {
+        "approval_document",
+        "attestation_document",
+    }
+    _DOCX_FILE_FIELDS = {
+        "approval_source",
+        "attestation_source",
+    }
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
+        if formfield is None:
+            return formfield
+        name = db_field.name
+        if name in self._PDF_FILE_FIELDS:
+            formfield.widget.attrs.setdefault("accept", ".pdf,application/pdf")
+        elif name in self._DOCX_FILE_FIELDS:
+            formfield.widget.attrs.setdefault(
+                "accept",
+                ".docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+        return formfield
 
 class ListTechnicalProposalInline(admin.TabularInline):
     model = ListTechnicalProposal
@@ -187,7 +521,9 @@ class RevisionTaskInline(admin.TabularInline):
 class WorkAssignmentInline(admin.TabularInline):
     model = WorkAssignment
     extra = 0
+    readonly_fields = ("wa_code_inline",)
     fields = (
+        "wa_code_inline",
         "name",
         "category",
         "executor",
@@ -198,9 +534,12 @@ class WorkAssignmentInline(admin.TabularInline):
         "version",
         "task",
         "target_deadline",
-        "result",
     )
     show_change_link = True
+
+    @admin.display(description="Код")
+    def wa_code_inline(self, obj):
+        return obj.wa_full_code or "—"
 
     def get_extra_buttons(self, obj):
         if obj and obj.id:
@@ -249,40 +588,373 @@ class ShipmentInline(admin.TabularInline):
     fields = (
         "serial_number",
         "manufacture_date",
-        "supplier",
+        "manufacturer_org",
+        "supplier_org",
         "product_passport",
         "shipment_date",
+        "buyer",
         "recipient",
         "note",
     )
-    autocomplete_fields = ("recipient", "supplier")
+    autocomplete_fields = ("buyer", "recipient", "manufacturer_org", "supplier_org")
+
+
+class ProductGroupDocumentInline(admin.TabularInline):
+    model = ProductGroupDocument
+    extra = 0
+    fields = ("title", "kind", "file")
+    verbose_name_plural = "Документы группы"
+
+
+@admin.register(ProductGroup)
+class ProductGroupAdmin(admin.ModelAdmin):
+    change_list_template = "admin/blog/productgroup/change_list.html"
+    list_display = (
+        "name",
+        "designation",
+        "main_purpose",
+        "main_documents_column",
+    )
+    list_display_links = ("name",)
+    search_fields = ("name", "designation", "main_purpose")
+    readonly_fields = (
+        "author",
+        "last_editor",
+        "date_of_creation",
+        "date_of_change",
+    )
+    fieldsets = (
+        (None, {
+            "fields": (
+                "name",
+                "designation",
+                "main_purpose",
+            ),
+        }),
+        ("Сведения о записи", {
+            "fields": (
+                "author",
+                "last_editor",
+                "date_of_creation",
+                "date_of_change",
+            ),
+        }),
+    )
+    inlines = (ProductGroupDocumentInline,)
+
+    def get_queryset(self, request):
+        qs = (
+            super()
+            .get_queryset(request)
+            .prefetch_related("documents")
+        )
+        raw = request.GET.get("id__exact") or request.GET.get("pk")
+        if raw is not None and str(raw).strip().isdigit():
+            qs = qs.filter(pk=int(raw))
+        return qs
+
+    @admin.display(description="Основные документы (PDF)")
+    def main_documents_column(self, obj):
+        if not obj.pk:
+            return "—"
+        docs = [
+            d
+            for d in obj.documents.all()
+            if d.kind == ProductGroupDocument.KIND_MAIN and d.file and d.file.name
+        ]
+        docs.sort(key=lambda x: x.pk)
+        if not docs:
+            return "—"
+        parts = []
+        for d in docs:
+            parts.append(
+                format_html(
+                    '<div style="margin:0 0 6px 0;line-height:1.35;">'
+                    '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>'
+                    "</div>",
+                    d.file.url,
+                    escape(d.title),
+                )
+            )
+        return mark_safe("".join(str(p) for p in parts))
+
+    def save_model(self, request, obj, form, change):
+        if request.user.is_authenticated:
+            if not change or obj.author_id is None:
+                obj.author = request.user
+            obj.last_editor = request.user
+        super().save_model(request, obj, form, change)
+
+
+class PostAdminForm(forms.ModelForm):
+    shipments_selector = forms.ModelMultipleChoiceField(
+        queryset=Shipment.objects.none(),
+        required=False,
+        label="Изделия к отгрузке",
+    )
+
+    class Meta:
+        model = Post
+        fields = "__all__"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        instance = getattr(self, "instance", None)
+        current_post_id = instance.pk if instance and instance.pk else None
+
+        qs = Shipment.objects.select_related("post").order_by("-date_of_creation", "-id")
+        if current_post_id:
+            # Показываем только уже привязанные к этой разработке отгрузки.
+            qs = qs.filter(post_id=current_post_id)
+            self.initial["shipments_selector"] = list(
+                Shipment.objects.filter(post_id=current_post_id).values_list("pk", flat=True)
+            )
+            self.fields["shipments_selector"].help_text = (
+                "Здесь отображаются отгрузки, уже привязанные к этой разработке."
+            )
+        else:
+            qs = qs.none()
+            self.fields["shipments_selector"].help_text = (
+                "После создания разработки здесь будут появляться отгрузки, "
+                "добавленные в сущности «Изделия к отгрузке» и привязанные к этой разработке."
+            )
+        self.fields["shipments_selector"].queryset = qs
 
 
 @admin.register(Post)
 class PostAdmin(admin.ModelAdmin):
+    form = PostAdminForm
     change_form_template = "admin/blog/universal_rkd_category_change_form.html"
     list_display = (
+        'wa_code_column',
         'name',
+        'name_full',
         'desig_document_post',
-        'modification_code',
+        'product_group_link',
         'author',
         'date_of_creation',
         'date_of_change',
     )
-    search_fields = ('name', 'modification_code')
-    readonly_fields = ('date_of_change',)
+    list_display_links = ('wa_code_column', 'name')
+    list_filter = ('product_group',)
+    search_fields = ('name', 'name_full', 'desig_document_post', 'modification_code', 'wa_code')
+    autocomplete_fields = ('product_group',)
+    readonly_fields = (
+        'author',
+        'last_editor',
+        'date_of_creation',
+        'date_of_change',
+        'group_name_display',
+        'group_designation_display',
+    )
+    fieldsets = (
+        ("Идентификация изделия (продукта)", {
+            "fields": (
+                "name",
+                "name_full",
+                "desig_document_post",
+            ),
+        }),
+        ("Принадлежность к группе", {
+            "fields": (
+                "is_group_modification",
+                "product_group",
+                "group_name_display",
+                "group_designation_display",
+                "main_purpose",
+            ),
+        }),
+        ("Описание изделия (продукта)", {
+            "fields": (
+                "group_modification_features",
+                "order_article",
+                "note",
+                "group_documents",
+            ),
+        }),
+        ("Стадия и готовность", {
+            "fields": ("litera", "trl"),
+        }),
+        ("Версионирование", {
+            "classes": ("collapse",),
+            "fields": ("version", "version_diff"),
+        }),
+        ("Системные сведения", {
+            "fields": (
+                "author",
+                "date_of_creation",
+                "last_editor",
+                "date_of_change",
+                "current_responsible",
+            ),
+        }),
+        ("Изделия к отгрузке", {
+            "fields": ("shipments_selector",),
+        }),
+        ("Дополнительные сведения", {
+            "classes": ("collapse",),
+            "fields": (
+                "modification_code",
+                "validity_date",
+                "develop_org",
+                "technical_specifications_ref",
+                "operating_manual_ref",
+                "product_passport_ref",
+            ),
+        }),
+    )
     inlines = [
-        # ListTechnicalProposalInline,  # ВТП — в форме «Разработка» не показываем
         TaskForDesignWorkInline,
         RevisionTaskInline,
         WorkAssignmentInline,
         UniversalRKDInline,
-        ShipmentInline,
     ]
+
+    @admin.display(description="Общее наименование группы изделий (продуктов)")
+    def group_name_display(self, obj):
+        value = (obj.product_group.name if obj and obj.product_group_id else "") or ""
+        return format_html('<span id="pg_val_name">{}</span>', value or "—")
+
+    @admin.display(description="Общее обозначение группы изделий (продуктов)")
+    def group_designation_display(self, obj):
+        value = (obj.product_group.designation if obj and obj.product_group_id else "") or ""
+        return format_html('<span id="pg_val_designation">{}</span>', value or "—")
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "product-group-data/<int:pk>/",
+                self.admin_site.admin_view(self.product_group_data_view),
+                name="blog_post_product_group_data",
+            ),
+        ]
+        return custom + urls
+
+    def product_group_data_view(self, request, pk):
+        from django.http import JsonResponse
+        try:
+            group = ProductGroup.objects.get(pk=pk)
+        except ProductGroup.DoesNotExist:
+            return JsonResponse({"ok": False}, status=404)
+        return JsonResponse({
+            "ok": True,
+            "name": group.name or "",
+            "designation": group.designation or "",
+            "main_purpose": group.main_purpose or "",
+        })
+
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        FormClass = super().get_form(request, obj, change=change, **kwargs)
+
+        class _PostForm(FormClass):
+            def __init__(self, *args, **form_kwargs):
+                super().__init__(*args, **form_kwargs)
+                for optional_name in (
+                    "current_responsible",
+                    "name_full",
+                    "desig_document_post",
+                    "product_group",
+                ):
+                    f = self.fields.get(optional_name)
+                    if f is not None:
+                        f.required = False
+
+                field = self.fields.get("develop_org")
+                if field and not self.is_bound:
+                    current_name = (getattr(self.instance, "develop_org", "") or "").strip()
+                    if current_name:
+                        org = RKDDeveloper.objects.filter(name=current_name).only("pk").first()
+                        if org:
+                            self.initial["develop_org"] = str(org.pk)
+
+        return _PostForm
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
+        if formfield is None or db_field.name != "develop_org":
+            return formfield
+
+        org_items = list(
+            RKDDeveloper.objects.order_by("name").values_list("pk", "name")
+        )
+        choices = [("", "---------")] + [(str(pk), name) for pk, name in org_items if name]
+        formfield.widget = forms.Select(choices=choices)
+        formfield.choices = choices
+        rel = Shipment._meta.get_field("manufacturer_org").remote_field
+        formfield.widget = RelatedFieldWidgetWrapper(
+            formfield.widget,
+            rel,
+            self.admin_site,
+            can_add_related=True,
+            can_change_related=True,
+            can_delete_related=True,
+            can_view_related=True,
+        )
+        formfield.help_text = ""
+        return formfield
 
     def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
         extra_context = _inject_rkd_category_json(extra_context)
+        extra_context = extra_context or {}
+        extra_context["product_group_data_url_template"] = reverse(
+            "admin:blog_post_product_group_data", args=[0]
+        )
         return super().changeform_view(request, object_id, form_url, extra_context)
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        return qs.select_related("product_group")
+
+    @admin.display(description="Общая группа разработок", ordering="product_group__name")
+    def product_group_link(self, obj):
+        if not obj or not obj.product_group_id:
+            return "—"
+        url = reverse("admin:blog_productgroup_changelist") + f"?id__exact={obj.product_group_id}"
+        return format_html(
+            '<a href="{}">{}</a>',
+            url,
+            escape(obj.product_group.name),
+        )
+
+    @admin.display(description="Код", ordering="wa_code")
+    def wa_code_column(self, obj):
+        return obj.wa_code or "—"
+
+    def save_model(self, request, obj, form, change):
+        raw_value = form.cleaned_data.get("develop_org")
+        if raw_value:
+            org = RKDDeveloper.objects.filter(pk=raw_value).only("name").first()
+            obj.develop_org = org.name if org else ""
+        else:
+            obj.develop_org = ""
+
+        if not obj.is_group_modification:
+            obj.product_group = None
+
+        if request.user.is_authenticated:
+            if not change or obj.author_id is None:
+                obj.author = request.user
+            obj.last_editor = request.user
+            if not obj.current_responsible_id:
+                obj.current_responsible = request.user
+
+        super().save_model(request, obj, form, change)
+
+        if not obj.wa_code:
+            from .helpers import assign_wa_code_to_post
+            assign_wa_code_to_post(obj)
+
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request, form, formsets, change)
+        post = form.instance
+        selected_ids = set(
+            (form.cleaned_data.get("shipments_selector") or Shipment.objects.none())
+            .values_list("pk", flat=True)
+        )
+        # Привязываем выбранные отгрузки к этой разработке (переназначаем при необходимости).
+        if selected_ids:
+            Shipment.objects.filter(pk__in=selected_ids).update(post=post)
 
     def save_formset(self, request, form, formset, change):
         instances = formset.save(commit=False)
@@ -301,6 +973,18 @@ class PostAdmin(admin.ModelAdmin):
                 instance.last_editor = user
                 if not instance.current_responsible_id:
                     instance.current_responsible = user
+
+            if isinstance(instance, WorkAssignment):
+                if instance.pk is None and request.user.is_authenticated:
+                    instance.author = request.user
+                    instance.last_editor = request.user
+                if instance.post_id:
+                    from .helpers import assign_wa_code_to_post, next_wa_number_for_post
+                    assign_wa_code_to_post(instance.post)
+                    if not instance.wa_number:
+                        instance.wa_number = next_wa_number_for_post(
+                            instance.post, exclude_pk=instance.pk
+                        )
 
             instance.save()
         formset.save_m2m()
@@ -325,26 +1009,89 @@ except admin.sites.NotRegistered:
 admin.site.register(Post, PostAdmin)
 
 
+class RKDDeveloperAdditionalFileInline(admin.TabularInline):
+    model = RKDDeveloperAdditionalFile
+    extra = 1
+    fields = ("file",)
+
+
 @admin.register(RKDDeveloper)
 class RKDDeveloperAdmin(admin.ModelAdmin):
+    list_display = (
+        "name",
+        "inn",
+        "charter_link",
+        "requisites_link",
+        "additional_files_links",
+    )
+    list_display_links = ("name",)
+    search_fields = ("name", "inn")
+    inlines = (RKDDeveloperAdditionalFileInline,)
     fields = (
         "name",
+        "inn",
         "charter",
         "requisites",
-        "additional_data",
     )
-    search_fields = ("name",)
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).prefetch_related("additional_files")
+
+    @admin.display(description="Устав")
+    def charter_link(self, obj):
+        if obj.charter:
+            return format_html(
+                '<a href="{}" target="_blank" rel="noopener noreferrer">Открыть файл</a>',
+                obj.charter.url,
+            )
+        return "—"
+
+    @admin.display(description="Реквизиты")
+    def requisites_link(self, obj):
+        if obj.requisites:
+            return format_html(
+                '<a href="{}" target="_blank" rel="noopener noreferrer">Открыть файл</a>',
+                obj.requisites.url,
+            )
+        return "—"
+
+    @admin.display(description="Дополнительные данные")
+    def additional_files_links(self, obj):
+        rows = list(obj.additional_files.all())
+        if not rows:
+            return "—"
+        parts = []
+        for af in rows:
+            f = getattr(af, "file", None)
+            if f and getattr(f, "name", None):
+                name = f.name.rsplit("/", 1)[-1]
+                parts.append(
+                    format_html(
+                        '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>',
+                        f.url,
+                        escape(name),
+                    )
+                )
+        if not parts:
+            return "—"
+        return mark_safe("<br>".join(str(p) for p in parts))
 
 
-@admin.register(ShipmentSupplier)
-class ShipmentSupplierAdmin(admin.ModelAdmin):
-    fields = (
-        "name",
-        "charter",
-        "requisites",
-        "additional_data",
+def _rkd_docs_section_header(title: str):
+    return mark_safe(
+        '<div style="'
+        "margin: 0 0 10px 0;"
+        "padding: 10px 14px;"
+        "font-weight: 700;"
+        "font-size: 13px;"
+        "letter-spacing: 0.4px;"
+        "text-transform: uppercase;"
+        "border-left: 4px solid var(--primary, #79aec8);"
+        "background: var(--darkened-bg, rgba(121,174,200,0.12));"
+        "color: var(--body-fg, inherit);"
+        "border-radius: 3px;"
+        f'">{escape(title)}</div>'
     )
-    search_fields = ("name",)
 
 
 @admin.register(UniversalRKD)
@@ -361,8 +1108,8 @@ class UniversalRKDAdmin(admin.ModelAdmin):
         "name",
         "rkd_documents_column",
         "quantity",
-        "rkd_planned_review_warning",
         "note",
+        "rkd_planned_review_warning",
     )
     list_display_links = ("name",)
     list_filter = ("specification_section", "status", "post")
@@ -409,27 +1156,19 @@ class UniversalRKDAdmin(admin.ModelAdmin):
         return mark_safe("<br>".join(str(p) for p in parts))
 
     @admin.display(
-        description="Срок пересмотра истекает",
+        description="Оповещение о пересмотре",
         ordering="validity_date",
     )
     def rkd_planned_review_warning(self, obj):
-        if not _universal_rkd_planned_review_show_warning(obj.validity_date):
+        days = getattr(obj, "review_reminder_days", 60)
+        if not _universal_rkd_planned_review_show_warning(
+            getattr(obj, "validity_date", None),
+            days=days,
+        ):
             return "—"
         return mark_safe(
             _admin_warning_triangle_html(
-                title="Плановый пересмотр: осталось не более 60 дней или срок прошёл",
-            )
-        )
-
-    @admin.display(description="Напоминание о пересмотре (до 60 дн.)")
-    def rkd_planned_review_warning_display(self, obj):
-        if not obj or not getattr(obj, "validity_date", None):
-            return "—"
-        if not _universal_rkd_planned_review_show_warning(obj.validity_date):
-            return "—"
-        return mark_safe(
-            _admin_warning_triangle_html(
-                title="Плановый пересмотр: осталось не более 60 дней или срок прошёл",
+                title=f"Плановый пересмотр: осталось не более {days} дн. или срок прошёл",
             )
         )
 
@@ -447,7 +1186,7 @@ class UniversalRKDAdmin(admin.ModelAdmin):
     readonly_fields = (
         "date_of_creation",
         "date_of_change",
-        "rkd_planned_review_warning_display",
+        "display_files_list",
     )
 
     fieldsets = (
@@ -475,17 +1214,44 @@ class UniversalRKDAdmin(admin.ModelAdmin):
                     "position",
                     "info_format",
                     "validity_date",
-                    "rkd_planned_review_warning_display",
+                    "review_reminder_days",
                     "language",
                     "internal_recipients",
                     "external_recipients",
                     "status",
                     "related_documents",
                     "develop_org",
-                    "document_uploaded_file",
-                    "approval_document",
-                    "attestation_document",
                 )
+            },
+        ),
+        (
+            None,
+            {
+                "description": _rkd_docs_section_header("Основной документ"),
+                "fields": (
+                    "document_uploaded_file",
+                    "document_source",
+                ),
+            },
+        ),
+        (
+            None,
+            {
+                "description": _rkd_docs_section_header("Лист утверждения"),
+                "fields": (
+                    "approval_document",
+                    "approval_source",
+                ),
+            },
+        ),
+        (
+            None,
+            {
+                "description": _rkd_docs_section_header("Удостоверяющий лист"),
+                "fields": (
+                    "attestation_document",
+                    "attestation_source",
+                ),
             },
         ),
         (
@@ -523,12 +1289,174 @@ class UniversalRKDAdmin(admin.ModelAdmin):
                 )
             },
         ),
+        (
+            "Файлы документа",
+            {
+                "fields": ("display_files_list",),
+            },
+        ),
     )
 
+    @admin.display(description="Файлы документа")
+    def display_files_list(self, obj):
+        card_style = (
+            "border: 1px solid var(--hairline-color, #e1e4e8);"
+            "border-radius: 6px;"
+            "background: var(--body-bg, #fff);"
+            "padding: 14px 16px;"
+            "max-width: 920px;"
+        )
+        section_title = (
+            "margin: 16px 0 8px 0;"
+            "font-size: 12px;"
+            "font-weight: 600;"
+            "letter-spacing: 0.02em;"
+            "text-transform: uppercase;"
+            "color: var(--body-quiet-color, #6b7280);"
+        )
+        row_base = "display:flex; gap:12px; align-items:flex-start; padding:8px 0;"
+        row_sep = "border-bottom: 1px solid var(--hairline-color, #eef0f3);"
+        label_style = "width: 220px; flex: 0 0 220px; color: var(--body-fg, #111); font-weight: 500;"
+        value_style = "flex: 1; min-width: 0; word-break: break-word;"
+        muted = "color: var(--body-quiet-color, #6b7280);"
+        link_style = "color: var(--link-fg, #417690); text-decoration: none;"
+
+        if not obj or not getattr(obj, "pk", None):
+            return format_html(
+                '<div style="{}">'
+                '<div style="{}">Сводка по файлам</div>'
+                '<div style="{}">После первого сохранения записи здесь появятся ссылки на загруженные файлы.</div>'
+                "</div>",
+                card_style,
+                section_title,
+                muted,
+            )
+
+        def _basename(f):
+            name = getattr(f, "name", "") or ""
+            return name.rsplit("/", 1)[-1] or name
+
+        def _row(
+            label: str,
+            f,
+            *,
+            with_sep: bool,
+            uploaded_by=None,
+            uploaded_at=None,
+            action_label: str = "загрузил",
+        ):
+            row_style = row_base + (row_sep if with_sep else "")
+            label_html = f'<div style="{label_style}">{escape(label)}</div>'
+            if not f:
+                return f'<div style="{row_style}">{label_html}<div style="{value_style} {muted}">не загружен</div></div>'
+            url = getattr(f, "url", "") or ""
+            filename = escape(_basename(f))
+            if url:
+                value = (
+                    f'<a href="{escape(url)}" target="_blank" rel="noopener noreferrer" style="{link_style}">{filename}</a>'
+                )
+            else:
+                value = f'<span style="{muted}">{filename}</span>'
+            if uploaded_by and uploaded_at:
+                value += (
+                    f'<div style="margin-top:6px;font-size:12px;{muted}">'
+                    f"{escape(action_label)}: {escape(uploaded_by.get_username())} · "
+                    f"{escape(uploaded_at.strftime('%d.%m.%Y %H:%M'))}"
+                    f"</div>"
+                )
+            elif uploaded_by:
+                value += (
+                    f'<div style="margin-top:6px;font-size:12px;{muted}">'
+                    f"{escape(action_label)}: {escape(uploaded_by.get_username())}"
+                    f"</div>"
+                )
+            return f'<div style="{row_style}">{label_html}<div style="{value_style}">{value}</div></div>'
+
+        html = f'<div style="{card_style}">'
+        html += f'<div style="{section_title}">Документы</div>'
+        last_editor = getattr(obj, "last_editor", None) or getattr(obj, "author", None)
+        changed_at = getattr(obj, "date_of_change", None)
+        html += _row(
+            "Документ — итоговый",
+            getattr(obj, "document_uploaded_file", None),
+            with_sep=True,
+            uploaded_by=last_editor,
+            uploaded_at=changed_at,
+            action_label="изменил",
+        )
+        html += _row(
+            "Документ — исходник",
+            getattr(obj, "document_source", None),
+            with_sep=True,
+            uploaded_by=last_editor,
+            uploaded_at=changed_at,
+            action_label="изменил",
+        )
+        html += _row(
+            "Лист утверждения — итоговый (PDF)",
+            getattr(obj, "approval_document", None),
+            with_sep=True,
+            uploaded_by=last_editor,
+            uploaded_at=changed_at,
+            action_label="изменил",
+        )
+        html += _row(
+            "Лист утверждения — исходник (DOCX)",
+            getattr(obj, "approval_source", None),
+            with_sep=True,
+            uploaded_by=last_editor,
+            uploaded_at=changed_at,
+            action_label="изменил",
+        )
+        html += _row(
+            "Удостоверяющий лист — итоговый (PDF)",
+            getattr(obj, "attestation_document", None),
+            with_sep=True,
+            uploaded_by=last_editor,
+            uploaded_at=changed_at,
+            action_label="изменил",
+        )
+        html += _row(
+            "Удостоверяющий лист — исходник (DOCX)",
+            getattr(obj, "attestation_source", None),
+            with_sep=False,
+            uploaded_by=last_editor,
+            uploaded_at=changed_at,
+            action_label="изменил",
+        )
+
+        html += f'<div style="{section_title}">Подписи</div>'
+        html += _row(
+            "Подпись проверки",
+            getattr(obj, "signature_checked", None),
+            with_sep=True,
+            uploaded_by=last_editor,
+            uploaded_at=changed_at,
+            action_label="изменил",
+        )
+        html += _row(
+            "Подпись утверждения",
+            getattr(obj, "signature_approved", None),
+            with_sep=False,
+            uploaded_by=last_editor,
+            uploaded_at=changed_at,
+            action_label="изменил",
+        )
+
+        html += "</div>"
+        return mark_safe(html)
+
     def get_ordering(self, request):
+        position_asc = F("_position_num").asc(nulls_last=True)
         if request.GET.get("post__id__exact"):
-            return ("section_sort_index", "order_in_section", "pk")
-        return ("post_id", "section_sort_index", "order_in_section", "pk")
+            return ("section_sort_index", position_asc, "order_in_section", "pk")
+        return (
+            "post_id",
+            "section_sort_index",
+            position_asc,
+            "order_in_section",
+            "pk",
+        )
 
     def changelist_view(self, request, extra_context=None):
         extra_context = dict(extra_context or {})
@@ -552,15 +1480,59 @@ class UniversalRKDAdmin(admin.ModelAdmin):
                 extra_context["rkd_breadcrumb_post"] = Post.objects.filter(pk=post_q).first()
         return super().changeform_view(request, object_id, form_url, extra_context)
 
+    def get_changeform_initial_data(self, request):
+        return super().get_changeform_initial_data(request)
+
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        return qs.select_related("post", "develop_org")
+        qs = qs.annotate(
+            _position_num=Case(
+                When(
+                    position__regex=r"^[0-9]+$",
+                    then=Cast("position", output_field=IntegerField()),
+                ),
+                default=Value(None),
+                output_field=IntegerField(),
+            )
+        )
+        return qs.select_related(
+            "post",
+            "develop_org",
+            "author",
+            "last_editor",
+            "current_responsible",
+            "checked_by",
+            "approved_by",
+        )
 
     def save_model(self, request, obj, form, change):
         if not change:
             obj.author = request.user
         obj.last_editor = request.user
         super().save_model(request, obj, form, change)
+
+    _PDF_FILE_FIELDS = {
+        "approval_document",
+        "attestation_document",
+    }
+    _DOCX_FILE_FIELDS = {
+        "approval_source",
+        "attestation_source",
+    }
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        formfield = super().formfield_for_dbfield(db_field, request, **kwargs)
+        if formfield is None:
+            return formfield
+        name = db_field.name
+        if name in self._PDF_FILE_FIELDS:
+            formfield.widget.attrs.setdefault("accept", ".pdf,application/pdf")
+        elif name in self._DOCX_FILE_FIELDS:
+            formfield.widget.attrs.setdefault(
+                "accept",
+                ".docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+        return formfield
 
 
 @admin.register(Shipment)
@@ -576,17 +1548,29 @@ class ShipmentAdmin(admin.ModelAdmin):
         "passport_link",
         "additional_files_links",
         "shipment_date",
-        "recipient",
+        "manufacturer_column",
+        "supplier_column",
+        "buyer_column",
+        "recipient_column",
         "note",
     )
     list_display_links = ("serial_number",)
     list_filter = ("post",)
-    search_fields = ("serial_number", "post__name", "note", "completeness", "supplier__name")
+    search_fields = (
+        "serial_number",
+        "post__name",
+        "note",
+        "completeness",
+        "manufacturer_org__name",
+        "supplier_org__name",
+    )
     ordering = ("post", "manufacture_date", "serial_number", "pk")
     autocomplete_fields = (
         "post",
+        "buyer",
         "recipient",
-        "supplier",
+        "manufacturer_org",
+        "supplier_org",
         "author",
         "last_editor",
         "current_responsible",
@@ -602,9 +1586,11 @@ class ShipmentAdmin(admin.ModelAdmin):
                 "fields": (
                     "serial_number",
                     "manufacture_date",
-                    "supplier",
+                    "manufacturer_org",
+                    "supplier_org",
                     "product_passport",
                     "shipment_date",
+                    "buyer",
                     "recipient",
                     "completeness",
                     "note",
@@ -629,7 +1615,7 @@ class ShipmentAdmin(admin.ModelAdmin):
         return (
             super()
             .get_queryset(request)
-            .select_related("post", "recipient", "supplier")
+            .select_related("post", "buyer", "recipient", "manufacturer_org", "supplier_org")
             .prefetch_related("additional_files")
         )
 
@@ -639,6 +1625,33 @@ class ShipmentAdmin(admin.ModelAdmin):
         if post_id:
             extra_context["shipment_breadcrumb_post"] = Post.objects.filter(pk=post_id).first()
         return super().changelist_view(request, extra_context)
+
+    @admin.display(description="Изготовитель", ordering="manufacturer_org__name")
+    def manufacturer_column(self, obj):
+        return obj.manufacturer_org or "—"
+
+    @admin.display(description="Поставщик", ordering="supplier_org__name")
+    def supplier_column(self, obj):
+        return obj.supplier_org or "—"
+
+    @admin.display(description="Покупатель", ordering="buyer__name_of_company")
+    def buyer_column(self, obj):
+        if not obj.buyer:
+            return "—"
+        return format_html(
+            '<span style="white-space: normal; word-break: break-word; display: inline-block; max-width: 220px;">{}</span>',
+            str(obj.buyer),
+        )
+
+    @admin.display(description="Грузополучатель", ordering="recipient")
+    def recipient_column(self, obj):
+        if not obj.recipient:
+            return "—"
+        return format_html(
+            '<span style="white-space: normal; word-break: break-word; '
+            'display: inline-block; max-width: 220px;">{}</span>',
+            str(obj.recipient),
+        )
 
     def get_readonly_fields(self, request, obj=None):
         """Создатель фиксируется при первом сохранении; в уже созданной записи только просмотр."""
@@ -698,7 +1711,7 @@ class ShipmentAdmin(admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
 
-@admin.register(ListTechnicalProposal)
+# @admin.register(ListTechnicalProposal)  # скрыто: замещено TechnicalProposal (ПТ)
 class ListTechnicalProposalAdmin(admin.ModelAdmin):
     list_display = ['name', 'category', 'desig_document_list_technical_proposal', 'status', 'date_of_creation']
     search_fields = ['name', 'desig_document_list_technical_proposal']
@@ -710,7 +1723,7 @@ class ListTechnicalProposalAdmin(admin.ModelAdmin):
         #    obj.name = obj.post.name
         #super().save_model(request, obj, form, change)
 
-@admin.register(GeneralDrawingProduct)
+# @admin.register(GeneralDrawingProduct)  # скрыто: замещено TechnicalProposal (ПТ)
 class GeneralDrawingProductAdmin(admin.ModelAdmin):
     list_display = (
         'name','category','author','date_of_creation','status','version',
@@ -719,7 +1732,7 @@ class GeneralDrawingProductAdmin(admin.ModelAdmin):
     list_filter = ('category', 'status', 'trl', 'litera')
     readonly_fields = ('date_of_change',)
 
-@admin.register(ElectronicModelProduct)
+# @admin.register(ElectronicModelProduct)  # скрыто: замещено TechnicalProposal (ПТ)
 class ElectronicModelProductAdmin(admin.ModelAdmin):
     list_display = (
         'name','desig_document_electronic_model_product','author','date_of_creation','status','version','trl',
@@ -728,7 +1741,7 @@ class ElectronicModelProductAdmin(admin.ModelAdmin):
     list_filter = ('status', 'trl', 'category', 'develop_org')
     readonly_fields = ('date_of_change',)
 
-@admin.register(GeneralElectricalDiagram)
+# @admin.register(GeneralElectricalDiagram)  # скрыто: замещено TechnicalProposal (ПТ)
 class GeneralElectricalDiagramAdmin(admin.ModelAdmin):
     list_display = (
         'name','desig_document','author','date_of_creation','status','version',
@@ -737,24 +1750,24 @@ class GeneralElectricalDiagramAdmin(admin.ModelAdmin):
     list_filter = ('status', 'trl', 'develop_org', 'language')
     readonly_fields = ('date_of_change',)
 
-@admin.register(SoftwareProduct)
+# @admin.register(SoftwareProduct)  # скрыто: замещено TechnicalProposal (ПТ)
 class SoftwareProductAdmin(admin.ModelAdmin):
     list_display = ('name', 'category', 'desig_document_software_product', 'status', 'version', 'date_of_creation')
     search_fields = ('name', 'desig_document_software_product', 'status')
     list_filter = ('status', 'trl', 'category', 'version')
     readonly_fields = ('date_of_change',)
 
-@admin.register(GeneralDrawingUnit)
+# @admin.register(GeneralDrawingUnit)  # скрыто: замещено TechnicalProposal (ПТ)
 class GeneralDrawingUnitAdmin(admin.ModelAdmin):
     list_display = ('name', 'desig_document_general_drawing_unit', 'status', 'version')
     readonly_fields = ('date_of_change',)
 
-@admin.register(ElectronicModelUnit)
+# @admin.register(ElectronicModelUnit)  # скрыто: замещено TechnicalProposal (ПТ)
 class ElectronicModelUnitAdmin(admin.ModelAdmin):
     list_display = ('name', 'desig_document_electronic_model_unit', 'status', 'version')
     readonly_fields = ('date_of_change',)
 
-@admin.register(DrawingPartUnit)
+# @admin.register(DrawingPartUnit)  # скрыто: замещено TechnicalProposal (ПТ)
 class DrawingPartUnitAdmin(admin.ModelAdmin):
     list_display = (
         'name',
@@ -797,7 +1810,7 @@ class DrawingPartUnitAdmin(admin.ModelAdmin):
         }),
     )
 
-@admin.register(ElectronicModelPartUnit)
+# @admin.register(ElectronicModelPartUnit)  # скрыто: замещено TechnicalProposal (ПТ)
 class ElectronicModelPartUnitAdmin(admin.ModelAdmin):
     list_display = (
         'name',
@@ -835,7 +1848,7 @@ class ElectronicModelPartUnitAdmin(admin.ModelAdmin):
         }),
     )
 
-@admin.register(DrawingPartProduct)
+# @admin.register(DrawingPartProduct)  # скрыто: замещено TechnicalProposal (ПТ)
 class DrawingPartProductAdmin(admin.ModelAdmin):
     list_display = (
         'name',
@@ -859,7 +1872,7 @@ class DrawingPartProductAdmin(admin.ModelAdmin):
         obj.last_editor = request.user
         super().save_model(request, obj, form, change)
 
-@admin.register(ElectronicModelPartProduct)
+# @admin.register(ElectronicModelPartProduct)  # скрыто: замещено TechnicalProposal (ПТ)
 class ElectronicModelPartProductAdmin(admin.ModelAdmin):
     list_display = (
         'desig_document_electronic_model_part_product', 'name', 'category',
@@ -876,7 +1889,7 @@ class ElectronicModelPartProductAdmin(admin.ModelAdmin):
         obj.last_editor = request.user
         super().save_model(request, obj, form, change)
 
-@admin.register(ReportTechnicalProposal)
+# @admin.register(ReportTechnicalProposal)  # скрыто: замещено TechnicalProposal (ПТ)
 class ReportTechnicalProposalAdmin(admin.ModelAdmin):
     list_display = (
         'name', 'category', 'status', 'version',
@@ -886,7 +1899,7 @@ class ReportTechnicalProposalAdmin(admin.ModelAdmin):
     search_fields = ('name', 'desig_document_report_technical_proposal', 'author__username')
     readonly_fields = ('date_of_change',)
 
-@admin.register(AddReportTechnicalProposal)
+# @admin.register(AddReportTechnicalProposal)  # скрыто: замещено TechnicalProposal (ПТ)
 class AddReportTechnicalProposalAdmin(admin.ModelAdmin):
     list_display = (
         'name',
@@ -927,7 +1940,7 @@ class AddReportTechnicalProposalAdmin(admin.ModelAdmin):
         }),
     )
 
-@admin.register(ProtocolTechnicalProposal)
+# @admin.register(ProtocolTechnicalProposal)  # скрыто: замещено TechnicalProposal (ПТ)
 class ProtocolTechnicalProposalAdmin(admin.ModelAdmin):
     list_display = (
         'name', 'category',
@@ -2375,26 +3388,263 @@ class DeadlineChangeInline(admin.TabularInline):
             initial['technical_assignment'] = tech_id
         return initial
 
+
+class WorkAssignmentSubtaskInline(admin.TabularInline):
+    model = WorkAssignmentSubtask
+    extra = 0
+    can_delete = True
+    show_change_link = False
+    fields = (
+        "parent_rz_display",
+        "subtask_code_link",
+        "executor",
+        "target_deadline",
+        "task_preview",
+        "criteria_preview",
+    )
+    readonly_fields = (
+        "parent_rz_display",
+        "subtask_code_link",
+        "executor",
+        "target_deadline",
+        "task_preview",
+        "criteria_preview",
+    )
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    @admin.display(description="РЗ")
+    def parent_rz_display(self, obj):
+        wa = getattr(obj, "work_assignment", None)
+        if wa is not None and getattr(wa, "pk", None):
+            return wa.wa_full_code or "—"
+        return "—"
+
+    @admin.display(description="Подзадача")
+    def subtask_code_link(self, obj):
+        if not obj.pk:
+            return "—"
+        code = obj.subtask_full_code or "—"
+        url = reverse("admin:blog_workassignmentsubtask_change", args=[obj.pk])
+        return format_html(
+            '<a href="{}" class="subtask-open-link"><strong>{}</strong></a>',
+            url,
+            code,
+        )
+
+    @admin.display(description="Задача")
+    def task_preview(self, obj):
+        t = (obj.task or "").strip()
+        if not t:
+            return "—"
+        return mark_safe(
+            '<div class="subtask-inline-cell">' + linebreaksbr(t) + "</div>"
+        )
+
+    @admin.display(description="Критерий выполнения")
+    def criteria_preview(self, obj):
+        t = (obj.acceptance_criteria or "").strip()
+        if t in ("", "---"):
+            return "—"
+        return mark_safe(
+            '<div class="subtask-inline-cell">' + linebreaksbr(t) + "</div>"
+        )
+
+
+@admin.register(WorkAssignmentSubtask)
+class WorkAssignmentSubtaskAdmin(admin.ModelAdmin):
+    def has_module_permission(self, request):
+        return False
+
+    def add_view(self, request, form_url="", extra_context=None):
+        extra = dict(extra_context or ())
+        extra["title"] = "Добавить подзадачу рабочего задания"
+        return super().add_view(request, form_url, extra_context=extra)
+
+    list_display = ("id", "work_assignment", "task_short", "target_deadline", "executor")
+    search_fields = ("task", "work_assignment__name")
+    readonly_fields = ("date_of_creation", "date_of_change")
+
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "category",
+                    "executor",
+                    "author",
+                    "current_responsible",
+                    "task",
+                    "acceptance_criteria",
+                )
+            },
+        ),
+        (
+            "Сроки",
+            {
+                "fields": (
+                    "target_deadline",
+                    "hard_deadline",
+                    ("time_window_start", "time_window_end"),
+                    "conditional_deadline",
+                )
+            },
+        ),
+        (
+            "Контроль и результат",
+            {
+                "fields": (
+                    "control_status",
+                    "control_date",
+                    "result_description",
+                    "uploaded_file",
+                )
+            },
+        ),
+        (
+            "Системная информация",
+            {
+                "fields": (
+                    "date_of_creation",
+                    "date_of_change",
+                    "last_editor",
+                )
+            },
+        ),
+    )
+
+    def get_exclude(self, request, obj=None):
+        excl = list(super().get_exclude(request, obj) or [])
+        for name in (
+            "work_assignment",
+            "version",
+            "deadline_version",
+            "reschedule_count",
+        ):
+            if name not in excl:
+                excl.append(name)
+        return excl
+
+    def _get_parent_wa(self, request, obj=None):
+        if obj is not None and getattr(obj, "work_assignment_id", None):
+            return obj.work_assignment
+        wa_id = request.GET.get("work_assignment") or request.POST.get("work_assignment")
+        if not wa_id:
+            return None
+        try:
+            return WorkAssignment.objects.get(pk=wa_id)
+        except (WorkAssignment.DoesNotExist, ValueError, TypeError):
+            return None
+
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = super().get_fieldsets(request, obj)
+        parent = self._get_parent_wa(request, obj)
+        if parent is None:
+            return fieldsets
+
+        code = parent.wa_full_code or ""
+        title = (parent.name or "").strip()
+        if code and title:
+            label = f"{code} — {title}"
+        else:
+            label = code or title or "—"
+
+        description = format_html(
+            '<div style="margin:0 0 12px;padding:10px 14px;'
+            'background:rgba(121,174,200,.10);border-left:3px solid #79aec8;'
+            'border-radius:4px;font-size:13px;">'
+            '<span style="opacity:.75;">Рабочее задание:</span> '
+            '<strong>{}</strong>'
+            '</div>',
+            label,
+        )
+
+        new_fieldsets = []
+        for i, (name, opts) in enumerate(fieldsets):
+            opts = dict(opts)
+            if i == 0:
+                opts["description"] = description
+            new_fieldsets.append((name, opts))
+        return new_fieldsets
+
+    @admin.display(description="Задача")
+    def task_short(self, obj):
+        t = (obj.task or "").strip().replace("\n", " ")
+        return (t[:60] + "...") if len(t) > 60 else (t or "—")
+
+    def get_changeform_initial_data(self, request):
+        initial = super().get_changeform_initial_data(request)
+        if request.user.is_authenticated:
+            initial.setdefault("author", request.user.pk)
+            initial.setdefault("last_editor", request.user.pk)
+            initial.setdefault("current_responsible", request.user.pk)
+        return initial
+
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        FormCls = super().get_form(request, obj, change=change, **kwargs)
+        parent_wa = self._get_parent_wa(request, obj)
+
+        class _SubtaskForm(FormCls):
+            def __init__(self, *args, **kw):
+                super().__init__(*args, **kw)
+                if parent_wa is not None and not getattr(self.instance, "work_assignment_id", None):
+                    self.instance.work_assignment = parent_wa
+
+        return _SubtaskForm
+
+    def save_model(self, request, obj, form, change):
+        user = request.user
+        if not change:
+            if user.is_authenticated:
+                obj.author = user
+                obj.last_editor = user
+            if not getattr(obj, "work_assignment_id", None):
+                parent = self._get_parent_wa(request)
+                if parent is not None:
+                    obj.work_assignment = parent
+
+        if obj.work_assignment_id and not obj.subtask_number:
+            from .helpers import next_subtask_number_for_wa
+            obj.subtask_number = next_subtask_number_for_wa(
+                obj.work_assignment, exclude_pk=obj.pk
+            )
+
+        super().save_model(request, obj, form, change)
+
+
 @admin.register(WorkAssignment)
 class WorkAssignmentAdmin(admin.ModelAdmin):
     #form = WorkAssignmentForm
 
     list_display = (
+        'wa_code_column',
         'name', 'author', 'executor', 'post',
         'effective_deadline_readonly',
         'overdue_flag',
-        'result', 'version',
+        'version',
         'target_deadline', 'hard_deadline',
         'control_status', 'control_date',
         'deadline_version', 'reschedule_count', # служебные
     )
-    search_fields = ('name','author__username','current_responsible__username')
-    list_filter = ('result','control_status', OverdueFilter)
+    list_display_links = ('wa_code_column', 'name')
+    ordering = ('post__wa_code', 'wa_number', 'pk')
+    search_fields = (
+        'name',
+        'author__username',
+        'current_responsible__username',
+        'post__wa_code',
+    )
+    list_filter = ('control_status', OverdueFilter)
+
+    @admin.display(description='Код', ordering='post__wa_code')
+    def wa_code_column(self, obj):
+        return obj.wa_full_code or '—'
 
     readonly_fields = ('date_of_creation','date_of_change',
                        'effective_deadline_readonly','deadline_version','reschedule_count')
 
-    inlines = [DeadlineChangeInline, AttachmentInline]
+    inlines = [DeadlineChangeInline, WorkAssignmentSubtaskInline, WorkAssignmentAttachmentInline]
 
     fieldsets = (
         ('Основная информация', {
@@ -2413,7 +3663,7 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
             )
         }),
         ('Контроль выполнения', {
-            'fields': ('control_status', 'control_date', 'result', 'result_description')
+            'fields': ('control_status', 'control_date', 'result_description')
         }),
         ('Системная информация', {
             'fields': ('route', 'date_of_creation', 'date_of_change', 'last_editor',
@@ -2421,24 +3671,95 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         }),
     )
 
-    def get_form(self, request, obj=None, change=False, **kwargs):
-        form = super().get_form(request, obj=obj, change=change, **kwargs)
-        for name in (
-            "target_deadline",
-            "hard_deadline",
-            "time_window_start",
-            "time_window_end",
-        ):
-            if name in form.base_fields:
-                form.base_fields[name].disabled = True
-        return form
+    def get_readonly_fields(self, request, obj=None):
+        fields = list(super().get_readonly_fields(request, obj))
+        if obj is not None:
+            for name in (
+                "target_deadline_display",
+                "hard_deadline_display",
+                "time_window_start_display",
+                "time_window_end_display",
+            ):
+                if name not in fields:
+                    fields.append(name)
+        return fields
+
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = super().get_fieldsets(request, obj)
+        if obj is None:
+            return fieldsets
+        rename = {
+            "target_deadline": "target_deadline_display",
+            "hard_deadline": "hard_deadline_display",
+            "time_window_start": "time_window_start_display",
+            "time_window_end": "time_window_end_display",
+        }
+        new_fieldsets = []
+        for title, opts in fieldsets:
+            opts = dict(opts)
+            new_fields = []
+            for f in opts.get("fields", ()):
+                if isinstance(f, (tuple, list)):
+                    new_fields.append(tuple(rename.get(x, x) for x in f))
+                else:
+                    new_fields.append(rename.get(f, f))
+            opts["fields"] = tuple(new_fields)
+            new_fieldsets.append((title, opts))
+        return new_fieldsets
+
+    @staticmethod
+    def _readonly_date_input(value):
+        if value in (None, ""):
+            text = ""
+        elif hasattr(value, "strftime"):
+            text = value.strftime("%d.%m.%Y")
+        else:
+            text = str(value)
+        return format_html(
+            '<input type="text" value="{}" disabled '
+            'style="background:var(--body-bg);color:var(--body-fg);'
+            'border:1px solid var(--border-color);padding:4px 6px;'
+            'border-radius:4px;width:160px;cursor:not-allowed;opacity:1;">',
+            text,
+        )
+
+    @admin.display(description="Целевой срок выполнения")
+    def target_deadline_display(self, obj):
+        return self._readonly_date_input(obj.target_deadline)
+
+    @admin.display(description="Абсолютный дедлайн")
+    def hard_deadline_display(self, obj):
+        return self._readonly_date_input(obj.hard_deadline)
+
+    @admin.display(description="Временное окно: с")
+    def time_window_start_display(self, obj):
+        return self._readonly_date_input(obj.time_window_start)
+
+    @admin.display(description="Временное окно: по")
+    def time_window_end_display(self, obj):
+        return self._readonly_date_input(obj.time_window_end)
 
     def get_changeform_initial_data(self, request):
         initial = super().get_changeform_initial_data(request)
         post_id = request.GET.get("post")
         if post_id:
             initial["post"] = post_id
+        if request.user.is_authenticated:
+            initial.setdefault("author", request.user.pk)
+            initial.setdefault("last_editor", request.user.pk)
         return initial
+
+    def save_model(self, request, obj, form, change):
+        user = request.user
+        if not change and user.is_authenticated:
+            obj.author = user
+            obj.last_editor = user
+        if obj.post_id:
+            from .helpers import assign_wa_code_to_post, next_wa_number_for_post
+            assign_wa_code_to_post(obj.post)
+            if not obj.wa_number:
+                obj.wa_number = next_wa_number_for_post(obj.post, exclude_pk=obj.pk)
+        super().save_model(request, obj, form, change)
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
@@ -2456,7 +3777,7 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         qs = qs.annotate(
             is_overdue=Case(
                 When(
-                    Q(result__isnull=True) & Q(effective_deadline_db__lt=today),
+                    Q(control_status__isnull=True) & Q(effective_deadline_db__lt=today),
                     then=True
                 ),
                 default=False,
@@ -2471,7 +3792,7 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
     effective_deadline_readonly.short_description = "Эффективный срок"
 
     def overdue_flag(self, obj):
-        return "—" if obj.result else ("⚠️" if obj.is_overdue else "—")
+        return "—" if obj.control_status else ("⚠️" if obj.is_overdue else "—")
     overdue_flag.short_description = "Просрочено?"
 
     def get_urls(self):

--- a/blog/apps.py
+++ b/blog/apps.py
@@ -1,7 +1,66 @@
 import types
 
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
 from django.utils.translation import gettext_lazy as _
+
+
+def _backfill_wa_codes(sender, **kwargs):
+    from .helpers import next_free_wa_code
+    from .models import Post, WorkAssignment, WorkAssignmentSubtask
+
+    posts_to_code = list(
+        Post.objects.filter(wa_code__isnull=True).order_by("pk")
+    )
+    if posts_to_code:
+        taken = set(
+            Post.objects.exclude(wa_code__isnull=True).values_list("wa_code", flat=True)
+        )
+        for post in posts_to_code:
+            code = next_free_wa_code(taken)
+            taken.add(code)
+            Post.objects.filter(pk=post.pk).update(wa_code=code)
+
+    unnumbered_post_ids = list(
+        WorkAssignment.objects.filter(post_id__isnull=False, wa_number__isnull=True)
+        .values_list("post_id", flat=True)
+        .distinct()
+    )
+    for post_id in unnumbered_post_ids:
+        pks = list(
+            WorkAssignment.objects.filter(post_id=post_id)
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+        for i, pk in enumerate(pks, start=1):
+            WorkAssignment.objects.filter(pk=pk).update(wa_number=i)
+
+    unnumbered_wa_ids = list(
+        WorkAssignmentSubtask.objects.filter(
+            work_assignment_id__isnull=False, subtask_number__isnull=True
+        )
+        .values_list("work_assignment_id", flat=True)
+        .distinct()
+    )
+    for wa_id in unnumbered_wa_ids:
+        from django.db.models import Max
+        last = (
+            WorkAssignmentSubtask.objects.filter(work_assignment_id=wa_id)
+            .exclude(subtask_number__isnull=True)
+            .aggregate(m=Max("subtask_number"))["m"]
+            or 0
+        )
+        pks = list(
+            WorkAssignmentSubtask.objects.filter(
+                work_assignment_id=wa_id, subtask_number__isnull=True
+            )
+            .order_by("pk")
+            .values_list("pk", flat=True)
+        )
+        for offset, pk in enumerate(pks, start=1):
+            WorkAssignmentSubtask.objects.filter(pk=pk).update(
+                subtask_number=last + offset
+            )
 
 
 class BlogConfig(AppConfig):
@@ -11,6 +70,8 @@ class BlogConfig(AppConfig):
 
     def ready(self):
         from django.contrib import admin
+
+        post_migrate.connect(_backfill_wa_codes, sender=self)
 
         site = admin.site
         _orig_get_app_list = site.get_app_list

--- a/blog/forms.py
+++ b/blog/forms.py
@@ -2,8 +2,12 @@ from typing import Optional
 from django import forms
 from django.contrib.admin.widgets import AdminDateWidget
 from django.utils import timezone
-from .models import WorkAssignment, UniversalRKD
-from .helpers import RKD_CATEGORY_BY_SECTION, section_has_category_choices
+from .models import WorkAssignment, UniversalRKD, TechnicalProposalDocument
+from .helpers import (
+    RKD_CATEGORY_BY_SECTION,
+    section_allows_position,
+    section_has_category_choices,
+)
 
 _CATEGORY_PLACEHOLDER = [("", "---------")]
 
@@ -73,6 +77,20 @@ class UniversalRKDForm(forms.ModelForm):
         widgets = {
             "validity_date": AdminDateWidget(),
         }
+        labels = {
+            "document_uploaded_file": "Итоговый",
+            "document_source": "Исходник",
+            "approval_document": "Итоговый (PDF)",
+            "approval_source": "Исходник (DOCX)",
+            "attestation_document": "Итоговый (PDF)",
+            "attestation_source": "Исходник (DOCX)",
+        }
+        help_texts = {
+            "approval_document": "Допустимый формат: PDF.",
+            "approval_source": "Допустимый формат: DOCX.",
+            "attestation_document": "Допустимый формат: PDF.",
+            "attestation_source": "Допустимый формат: DOCX.",
+        }
 
     def _current_specification_section(self) -> Optional[str]:
         if self.is_bound:
@@ -110,4 +128,26 @@ class UniversalRKDForm(forms.ModelForm):
         section = cleaned.get("specification_section") or ""
         if not section_has_category_choices(section):
             cleaned["category"] = ""
+        if not section_allows_position(section):
+            cleaned["position"] = "-"
         return cleaned
+
+
+class TechnicalProposalForm(forms.ModelForm):
+    class Meta:
+        model = TechnicalProposalDocument
+        fields = "__all__"
+        labels = {
+            "document_uploaded_file": "Итоговый",
+            "document_source": "Исходник",
+            "approval_document": "Итоговый (PDF)",
+            "approval_source": "Исходник (DOCX)",
+            "attestation_document": "Итоговый (PDF)",
+            "attestation_source": "Исходник (DOCX)",
+        }
+        help_texts = {
+            "approval_document": "Допустимый формат: PDF.",
+            "approval_source": "Допустимый формат: DOCX.",
+            "attestation_document": "Допустимый формат: PDF.",
+            "attestation_source": "Допустимый формат: DOCX.",
+        }

--- a/blog/helpers.py
+++ b/blog/helpers.py
@@ -135,6 +135,16 @@ RKD_CATEGORY_BY_SECTION: dict[str, tuple[str, ...]] = {
     "documentation": _CATEGORY_DOCUMENTATION,
 }
 
+POSITION_EDITABLE_SECTIONS: frozenset[str] = frozenset(
+    {
+        "assembly_units",
+        "parts",
+        "standard_products",
+        "other_products",
+        "materials",
+    }
+)
+
 
 def rkd_category_by_section_json() -> str:
     """JSON для JS в админке (зависимый select «Категория»)."""
@@ -154,4 +164,71 @@ def allowed_categories_for_section(section: str) -> frozenset[str]:
 
 def section_has_category_choices(section: str) -> bool:
     return bool(RKD_CATEGORY_BY_SECTION.get(section, ()))
+
+
+def section_allows_position(section: str) -> bool:
+    return section in POSITION_EDITABLE_SECTIONS
+
+
+WA_CODE_LENGTH = 3
+_WA_CODE_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+def _wa_index_to_code(index: int) -> str:
+    """0 → 'AAA', 1 → 'AAB', 26 → 'ABA', и т.д."""
+    n = len(_WA_CODE_ALPHABET)
+    chars = []
+    for _ in range(WA_CODE_LENGTH):
+        index, r = divmod(index, n)
+        chars.append(_WA_CODE_ALPHABET[r])
+    return "".join(reversed(chars))
+
+
+def _wa_code_to_index(code: str) -> int:
+    n = len(_WA_CODE_ALPHABET)
+    idx = 0
+    for ch in code:
+        idx = idx * n + _WA_CODE_ALPHABET.index(ch)
+    return idx
+
+
+def next_free_wa_code(taken_codes) -> str:
+    taken = set(taken_codes or ())
+    max_idx = len(_WA_CODE_ALPHABET) ** WA_CODE_LENGTH
+    for i in range(max_idx):
+        code = _wa_index_to_code(i)
+        if code not in taken:
+            return code
+    raise RuntimeError("Свободные буквенные коды для рабочих заданий закончились.")
+
+
+def assign_wa_code_to_post(post) -> str:
+    if getattr(post, "wa_code", None):
+        return post.wa_code
+    Post = post.__class__
+    taken = Post.objects.exclude(pk=post.pk).exclude(wa_code__isnull=True).values_list("wa_code", flat=True)
+    code = next_free_wa_code(taken)
+    post.wa_code = code
+    Post.objects.filter(pk=post.pk).update(wa_code=code)
+    return code
+
+
+def next_wa_number_for_post(post, exclude_pk=None) -> int:
+    from django.db.models import Max
+    from .models import WorkAssignment
+    qs = WorkAssignment.objects.filter(post=post)
+    if exclude_pk is not None:
+        qs = qs.exclude(pk=exclude_pk)
+    last = qs.aggregate(m=Max("wa_number"))["m"] or 0
+    return last + 1
+
+
+def next_subtask_number_for_wa(work_assignment, exclude_pk=None) -> int:
+    from django.db.models import Max
+    from .models import WorkAssignmentSubtask
+    qs = WorkAssignmentSubtask.objects.filter(work_assignment=work_assignment)
+    if exclude_pk is not None:
+        qs = qs.exclude(pk=exclude_pk)
+    last = qs.aggregate(m=Max("subtask_number"))["m"] or 0
+    return last + 1
 

--- a/blog/models.py
+++ b/blog/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.utils import timezone
 from django.core.exceptions import ValidationError
+from django.core.validators import FileExtensionValidator, RegexValidator
 from django.contrib.auth import get_user_model
 from django.conf import settings
 from django.db import transaction
@@ -11,6 +12,7 @@ from django.contrib.contenttypes.models import ContentType
 from .helpers import (
     SPECIFICATION_SECTION_CHOICES,
     allowed_categories_for_section,
+    section_allows_position,
     section_has_category_choices,
     specification_section_sort_index,
 )
@@ -88,7 +90,112 @@ class ConformityAssessment(models.Model):
 
 
 
-# Модель Post
+class ProductGroup(models.Model):
+    name = models.CharField(
+        max_length=200,
+        unique=True,
+        verbose_name="Общее наименование группы изделий (продуктов)",
+    )
+    designation = models.CharField(
+        max_length=100,
+        blank=True,
+        default="",
+        verbose_name="Общее обозначение группы изделий (продуктов)",
+    )
+    main_purpose = models.TextField(
+        max_length=2000,
+        blank=True,
+        default="",
+        verbose_name="Основное назначение изделия (продукта)",
+    )
+    author = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="created_product_groups",
+        verbose_name="Автор",
+    )
+    last_editor = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="edited_product_groups",
+        verbose_name="Последний редактор",
+    )
+    date_of_creation = models.DateTimeField(
+        default=timezone.now,
+        verbose_name="Дата и время создания",
+    )
+    date_of_change = models.DateTimeField(
+        auto_now=True,
+        verbose_name="Дата и время последнего изменения",
+    )
+
+    class Meta:
+        verbose_name = "Общая группа разработок"
+        verbose_name_plural = "Общие группы разработок"
+        ordering = ("name",)
+
+    def __str__(self):
+        return self.name
+
+
+class ProductGroupDocument(models.Model):
+    """Документы, привязанные к общей группе разработок (основной PDF / исходник)."""
+
+    KIND_MAIN = "main"
+    KIND_SOURCE = "source"
+    KIND_CHOICES = [
+        (KIND_MAIN, "Основной (PDF)"),
+        (KIND_SOURCE, "Исходный (DOCX)"),
+    ]
+
+    product_group = models.ForeignKey(
+        ProductGroup,
+        on_delete=models.CASCADE,
+        related_name="documents",
+        verbose_name="Общая группа разработок",
+    )
+    title = models.CharField(
+        max_length=500,
+        verbose_name="Название документа",
+    )
+    kind = models.CharField(
+        max_length=20,
+        choices=KIND_CHOICES,
+        default=KIND_MAIN,
+        verbose_name="Вид документа",
+    )
+    file = models.FileField(
+        upload_to="blog/productgroup/documents/%Y/%m/",
+        verbose_name="Файл",
+    )
+
+    class Meta:
+        verbose_name = "Документ группы разработок"
+        verbose_name_plural = "Документы группы разработок"
+        ordering = ("pk",)
+
+    def __str__(self):
+        return self.title
+
+    def clean(self):
+        super().clean()
+        f = self.file
+        if not f or not getattr(f, "name", None):
+            return
+        name = f.name.lower()
+        ext = name.rsplit(".", 1)[-1] if "." in name else ""
+        if self.kind == self.KIND_MAIN and ext != "pdf":
+            raise ValidationError({"file": "Для вида «Основной» допускается только PDF."})
+        if self.kind == self.KIND_SOURCE and ext not in ("docx", "doc"):
+            raise ValidationError(
+                {"file": "Для вида «Исходный» загрузите DOCX или DOC."}
+            )
+
+
 class Post(models.Model):
     LITERA_CHOICES = [
         ('П-', 'П-'),
@@ -100,8 +207,76 @@ class Post(models.Model):
         ('1', '1'),
     ]
 
-    name = models.CharField(max_length=100, unique=True, verbose_name="Наименование")
-    desig_document_post = models.CharField(max_length=50, null=True, verbose_name="Обозначение изделия")
+    name = models.CharField(
+        max_length=100,
+        unique=True,
+        verbose_name="Наименование изделия (продукта) краткое",
+    )
+    name_full = models.CharField(
+        max_length=255,
+        blank=True,
+        null=True,
+        unique=True,
+        verbose_name="Наименование изделия (продукта) полное",
+    )
+    desig_document_post = models.CharField(
+        max_length=50,
+        blank=True,
+        null=True,
+        unique=True,
+        verbose_name="Обозначение изделия (продукта)",
+    )
+    is_group_modification = models.BooleanField(
+        default=False,
+        verbose_name="Является исполнением (модификацией) группы изделий",
+    )
+    product_group = models.ForeignKey(
+        "ProductGroup",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="posts",
+        verbose_name="Общая группа разработок",
+    )
+    group_modification_features = models.TextField(
+        max_length=2000,
+        blank=True,
+        default="",
+        verbose_name="Характерные особенности исполнения (модификация)",
+    )
+    main_purpose = models.TextField(
+        max_length=2000,
+        blank=True,
+        default="",
+        verbose_name="Основное назначение изделия (продукта)",
+    )
+    order_article = models.CharField(
+        max_length=200,
+        blank=True,
+        default="",
+        verbose_name="Запись при заказе (артикул)",
+    )
+    note = models.TextField(
+        max_length=2000,
+        blank=True,
+        default="",
+        verbose_name="Примечание",
+    )
+    group_documents = models.FileField(
+        upload_to="blog/post/group_documents/%Y/%m/",
+        blank=True,
+        null=True,
+        verbose_name="Общие документы группы изделий",
+    )
+    wa_code = models.CharField(
+        max_length=3,
+        blank=True,
+        null=True,
+        unique=True,
+        editable=False,
+        verbose_name="Буквенный код для рабочих заданий",
+        help_text="Назначается автоматически при создании первого рабочего задания.",
+    )
     author = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name='created_posts',
                                verbose_name="Автор")
     last_editor = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name='edited_posts',
@@ -118,8 +293,6 @@ class Post(models.Model):
     trl = models.CharField(max_length=10, choices=TRL_CHOICES, default='1-',
                            verbose_name="Уровень готовности технологий (TRL)")
 
-    technical_proposal = models.OneToOneField('TechnicalProposal', on_delete=models.SET_NULL, blank=True, null=True,
-                                              related_name='Post', verbose_name='Техническое предложение')
     prelim_design = models.OneToOneField(prelim_design, on_delete=models.SET_NULL, null=True, blank=True,
                                          verbose_name="Эскизный проект")
     technical_design = models.OneToOneField(technical_design, on_delete=models.SET_NULL, null=True, blank=True,
@@ -178,6 +351,17 @@ class Post(models.Model):
 
     def __str__(self):
         return self.name
+
+    def clean(self):
+        super().clean()
+        if not (self.name_full or "").strip():
+            self.name_full = None
+        if not (self.desig_document_post or "").strip():
+            self.desig_document_post = None
+        if self.is_group_modification and not self.product_group_id:
+            raise ValidationError({
+                "product_group": "Выберите общую группу разработок или снимите галочку.",
+            })
 
 
 class GeneralDrawingProduct(models.Model):
@@ -1006,49 +1190,253 @@ class ListTechnicalProposal(models.Model):
         verbose_name_plural = 'Ведомости технического предложения'
 
 
-# Модель TechnicalProposal
-class TechnicalProposal(models.Model):
+class TechnicalProposalDocument(models.Model):
+    """Техническое предложение (ПТ) — одна запись = один документ в рамках разработки."""
+
+    DOCUMENT_KIND_CHOICES = [
+        ("scheme", "Схема"),
+        ("drawing_part", "Чертеж детали"),
+        ("drawing_assembly", "Чертеж сборочной единицы"),
+        ("model_part", "Электронная модель детали"),
+        ("model_assembly", "Электронная модель сборочной единицы"),
+        ("software", "Программное обеспечение"),
+        ("protocol", "Протокол"),
+        ("report", "Пояснительная записка"),
+        ("addition", "Приложение"),
+    ]
+
+    STATUS_CHOICES = [
+        ("В разработке", "В разработке"),
+        ("Выпущен", "Выпущен"),
+    ]
+
     LITERA_CHOICES = [
-        ('П-', 'П-'),
-        ('П', 'П'),
+        ("П-", "П-"),
+        ("П", "П"),
     ]
 
     TRL_CHOICES = [
-        ('1-', '1-'),
-        ('1', '1'),
+        ("1-", "1-"),
+        ("1", "1"),
+        ("2-", "2-"),
+        ("2", "2"),
+        ("3-", "3-"),
+        ("3", "3"),
     ]
-    name = models.CharField(max_length=200, unique=True, verbose_name="Категория")
-    author = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, verbose_name="Автор")
+
+    INFO_FORMAT_CHOICES = [
+        ("ДЭ", "ДЭ"),
+        ("ДБ", "ДБ"),
+    ]
+
+    post = models.ForeignKey(
+        "Post",
+        on_delete=models.CASCADE,
+        related_name="technical_proposal_entries",
+        null=True,
+        blank=True,
+        verbose_name="Разработка (модификация)",
+    )
+    document_kind = models.CharField(
+        max_length=32,
+        choices=DOCUMENT_KIND_CHOICES,
+        blank=True,
+        default="",
+        verbose_name="Вид документа ПТ",
+    )
+    category = models.CharField(
+        max_length=50,
+        blank=True,
+        default="",
+        verbose_name="Категория (код вида документа)",
+    )
+
+    name = models.CharField(max_length=200, verbose_name="Наименование")
+    desig_document = models.CharField(
+        max_length=50,
+        blank=True,
+        default="",
+        verbose_name="Обозначение документа",
+    )
+
+    litera = models.CharField(
+        max_length=20,
+        choices=LITERA_CHOICES,
+        default="П-",
+        verbose_name="Стадия разработки (литера)",
+    )
+    trl = models.CharField(
+        max_length=10,
+        choices=TRL_CHOICES,
+        default="1-",
+        verbose_name="Уровень готовности технологий (TRL)",
+    )
+
+    author = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="technical_proposal_created",
+        verbose_name="Автор",
+    )
     date_of_creation = models.DateTimeField(default=timezone.now, verbose_name="Дата и время создания")
-    last_editor = models.ForeignKey(User, related_name='tp_last_edited_by', on_delete=models.SET_NULL, null=True, verbose_name="Последний редактор")
+    last_editor = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="technical_proposal_edited",
+        verbose_name="Последний редактор",
+    )
+    version = models.CharField(max_length=20, blank=True, default="1", verbose_name="Версия")
     date_of_change = models.DateTimeField(auto_now=True, verbose_name="Дата и время последнего изменения")
-    current_responsible = models.ForeignKey(User, related_name='tp_current_responsible', on_delete=models.SET_NULL, null=True, verbose_name="Текущий ответственный")
-    version = models.CharField(max_length=20, blank=True, default='1', verbose_name="Версия")
-    version_diff = models.TextField(max_length=1000, blank=True, default='Стартовая версия', verbose_name="Сравнение версий")
-    litera = models.CharField(max_length=20, choices=LITERA_CHOICES, default='П-', verbose_name="Стадия разработки  (Литера)")
-    trl = models.CharField(max_length=10, choices=TRL_CHOICES, default='1-', verbose_name="Уровень готовности технологий (TRL)")
+    current_responsible = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="technical_proposal_responsible",
+        verbose_name="Текущий ответственный",
+    )
 
-    list_technical_proposal = models.OneToOneField(ListTechnicalProposal, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="Ведомость технического предложения")
-    general_drawing_product = models.OneToOneField(GeneralDrawingProduct, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="Чертеж общего вида изделия")
-    electronic_model_product = models.OneToOneField(ElectronicModelProduct, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="Электронная модель изделия ")
-    general_electrical_diagram = models.OneToOneField(GeneralElectricalDiagram, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="Схема электрическая общая")
-    software_product = models.OneToOneField(SoftwareProduct, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="Программное обеспечение Технического предложения")
-    report_technical_proposal = models.OneToOneField(ReportTechnicalProposal, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="Пояснительная записка ПЗ ПТ")
-    protocol_technical_proposal = models.OneToOneField(ProtocolTechnicalProposal, on_delete=models.SET_NULL, null=True, blank=True, verbose_name="Протокол. Техническое предложение")
+    info_format = models.CharField(
+        max_length=2,
+        choices=INFO_FORMAT_CHOICES,
+        default="ДЭ",
+        verbose_name="Вид носителя информации",
+    )
+    status = models.CharField(
+        max_length=32,
+        choices=STATUS_CHOICES,
+        default="В разработке",
+        verbose_name="Статус (состояние)",
+    )
+    related_documents = models.TextField(
+        max_length=1000,
+        blank=True,
+        default="",
+        verbose_name="Связанные сопроводительные документы",
+    )
+    develop_org = models.ForeignKey(
+        "RKDDeveloper",
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        verbose_name="Организация-разработчик",
+    )
 
-    general_drawing_unit = models.ManyToManyField(GeneralDrawingUnit, blank=True, verbose_name="Чертеж общего вида сборочной единицы")
-    electronic_model_unit = models.ManyToManyField(ElectronicModelUnit, blank=True, verbose_name="Электронная модель сборочной единицы")
-    drawing_part_unit = models.ManyToManyField(DrawingPartUnit, blank=True, verbose_name="Чертеж детали сборочной единицы")
-    electronic_model_part_unit = models.ManyToManyField(ElectronicModelPartUnit, blank=True, verbose_name="Электронная модель детали сборочной единицы")
-    drawing_part_product = models.ManyToManyField(DrawingPartProduct, blank=True, verbose_name="Чертеж детали изделия")
-    electronic_model_part_product =  models.ManyToManyField(ElectronicModelPartProduct, blank=True, verbose_name="Электронная модель детали изделия")
-    add_report_technical_proposal = models.ManyToManyField(AddReportTechnicalProposal, blank=True, verbose_name="ПЗ ПТ Приложение")
+    document_uploaded_file = models.FileField(
+        upload_to="blog/technical_proposal/documents/%Y/%m/",
+        blank=True,
+        null=True,
+        verbose_name="Документ: итоговый",
+    )
+    document_source = models.FileField(
+        upload_to="blog/technical_proposal/documents/source/%Y/%m/",
+        blank=True,
+        null=True,
+        verbose_name="Документ: исходник",
+    )
+    approval_document = models.FileField(
+        upload_to="blog/technical_proposal/approval/%Y/%m/",
+        blank=True,
+        null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["pdf"])],
+        verbose_name="Лист утверждения: итоговый (PDF)",
+        help_text="Допустимый формат: PDF.",
+    )
+    approval_source = models.FileField(
+        upload_to="blog/technical_proposal/approval/source/%Y/%m/",
+        blank=True,
+        null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["docx"])],
+        verbose_name="Лист утверждения: исходник (DOCX)",
+        help_text="Допустимый формат: DOCX.",
+    )
+    attestation_document = models.FileField(
+        upload_to="blog/technical_proposal/attestation/%Y/%m/",
+        blank=True,
+        null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["pdf"])],
+        verbose_name="Удостоверяющий лист: итоговый (PDF)",
+        help_text="Допустимый формат: PDF.",
+    )
+    attestation_source = models.FileField(
+        upload_to="blog/technical_proposal/attestation/source/%Y/%m/",
+        blank=True,
+        null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["docx"])],
+        verbose_name="Удостоверяющий лист: исходник (DOCX)",
+        help_text="Допустимый формат: DOCX.",
+    )
+
+    checked_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="technical_proposal_checked",
+        verbose_name="Проверил / согласовал",
+    )
+    signature_checked = models.FileField(
+        upload_to="blog/technical_proposal/signatures/checked/%Y/%m/",
+        blank=True,
+        null=True,
+        verbose_name="Подпись проверки (файл)",
+    )
+    approved_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="technical_proposal_approved",
+        verbose_name="Утвердил",
+    )
+    signature_approved = models.FileField(
+        upload_to="blog/technical_proposal/signatures/approved/%Y/%m/",
+        blank=True,
+        null=True,
+        verbose_name="Подпись утверждения (файл)",
+    )
+
+    comment = models.TextField(max_length=1000, blank=True, default="", verbose_name="Комментарий")
 
     class Meta:
-        verbose_name = "Техническое предложение"
+        verbose_name = "техническое предложение"
         verbose_name_plural = "Технические предложения"
+        ordering = ("post_id", "document_kind", "pk")
 
-    def __str__(self): return self.name
+    def __str__(self):
+        return f"{self.desig_document} — {self.name}" if self.desig_document else (self.name or "ПТ")
+
+    def clean(self):
+        super().clean()
+        if not (self.name or "").strip():
+            raise ValidationError({"name": "Укажите наименование."})
+        if not (self.desig_document or "").strip():
+            raise ValidationError({"desig_document": "Укажите обозначение документа."})
+        if not (self.document_kind or "").strip():
+            raise ValidationError({"document_kind": "Укажите вид документа ПТ."})
+        if (
+            self.status
+            and self.status != "В разработке"
+            and not self.document_uploaded_file
+            and not self.document_source
+        ):
+            raise ValidationError(
+                {
+                    "document_uploaded_file": (
+                        "Загрузите документ (итоговый PDF или исходник DOCX) "
+                        "для статуса «Выпущен»."
+                    )
+                }
+            )
+        if self.status == "Выпущен":
+            if not self.checked_by:
+                raise ValidationError({"checked_by": "Для статуса «Выпущен» укажите проверившего."})
+            if not self.signature_checked:
+                raise ValidationError({"signature_checked": "Для статуса «Выпущен» приложите подпись проверки."})
 
 
 class TaskForDesignWork(models.Model):
@@ -1067,7 +1455,7 @@ class TaskForDesignWork(models.Model):
 
     name = models.CharField(max_length=100, unique=True, blank=True, null=True, verbose_name="наименование")
     category = models.CharField(max_length=100, default="ТЗ ОКР", verbose_name="категория")
-    post = models.ForeignKey('Post', on_delete=models.CASCADE, null=True, blank=True, related_name='task_for_design_work', verbose_name="Связанная разработка")
+    post = models.ForeignKey('Post', on_delete=models.CASCADE, null=True, blank=True, related_name='task_for_design_work', verbose_name="Связанная разработка/проект")
     info_format = models.CharField(max_length=100, choices=INFO_FORMAT_CHOICES, blank=True, null=True,
                                    verbose_name="формат предоставления информации")
     author = models.ForeignKey(User, on_delete=models.CASCADE, related_name="created_designtasks", verbose_name="автор")
@@ -1123,7 +1511,7 @@ class RevisionTask(models.Model):
 
     name = models.CharField(max_length=100, unique=True, blank=True, null=True, verbose_name="наименование")
     category = models.CharField(max_length=100, default="ТЗ Д", verbose_name="категория")
-    post = models.ForeignKey('Post', on_delete=models.CASCADE, null=True, blank=True, related_name='revision_tasks', verbose_name="Связанная разработка")
+    post = models.ForeignKey('Post', on_delete=models.CASCADE, null=True, blank=True, related_name='revision_tasks', verbose_name="Связанная разработка/проект")
     info_format = models.CharField(max_length=100, choices=INFO_FORMAT_CHOICES, blank=True, null=True, verbose_name="формат")
     author = models.ForeignKey(User, on_delete=models.CASCADE, related_name="created_revisions", verbose_name="автор")
     date_of_creation = models.DateTimeField(default=timezone.now, verbose_name="Дата и время создания")
@@ -1171,17 +1559,24 @@ class WorkAssignment(models.Model):
     ]
 
     TEMP_STATUS_CHOICES = [
-        ('done', 'Выполнено'),
-        ('changed', 'Срок выполнения изменен'),
-        ('canceled', 'Задание отменено'),
+        ('on_time', 'Выполнено в срок'),
+        ('rescheduled', 'Выполнено с переносом сроков'),
+        ('partial', 'Выполнено частично'),
+        ('not_done', 'Не выполнено'),
     ]
 
     # базовые поля
     name = models.CharField(max_length=100, unique=True, blank=True, null=True, verbose_name="Наименование")
+    wa_number = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        editable=False,
+        verbose_name="Порядковый номер в рамках разработки",
+    )
     category = models.CharField(max_length=100, default="РЗ", verbose_name="Категория")
     executor = models.ForeignKey(User, on_delete=models.CASCADE, null= True, related_name= "executed_workassignments", verbose_name="Исполнитель")
     task = models.CharField('Задача', max_length=255, blank=True)
-    post = models.ForeignKey('Post', on_delete=models.CASCADE, null=True, blank=True, related_name='work_assignments', verbose_name="Связанная разработка")
+    post = models.ForeignKey('Post', on_delete=models.CASCADE, null=True, blank=True, related_name='work_assignments', verbose_name="Связанная разработка/проект")
     author = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name="Автор")
     date_of_creation = models.DateTimeField(default=timezone.now, verbose_name="Дата и время создания")
     last_editor = models.ForeignKey(
@@ -1216,13 +1611,13 @@ class WorkAssignment(models.Model):
     #uploaded_file = models.FileField(upload_to='uploads/', blank = True, verbose_name="Приложение к РЗ")
 
     control_status = models.CharField(
-        "Контроль срока — статус",
+        "Контроль выполнения - статус",
         max_length=20,
         null=True,
         blank=True,
         choices=TEMP_STATUS_CHOICES,
     )
-    control_date = models.DateField("Контроль срока — дата", null=True, blank=True)
+    control_date = models.DateField("Дата фиксации статуса", null=True, blank=True)
 
    #def _build_name(self) -> str:
     #    sep = " — "  # любой разделитель
@@ -1294,7 +1689,7 @@ class WorkAssignment(models.Model):
         return self.deadline
 
     def is_active(self):
-        return self.control_status not in ('canceled',)
+        return self.control_status not in ('not_done',)
 
     def is_overdue(self, today=None):
         if not self.is_active():
@@ -1321,8 +1716,150 @@ class WorkAssignment(models.Model):
             self.name = self.post.name
         super().save(*args, **kwargs)
 
+    @property
+    def wa_full_code(self) -> str:
+        code = getattr(self.post, "wa_code", None) if self.post_id else None
+        if code and self.wa_number:
+            return f"{code}-{self.wa_number}"
+        return ""
+
     def __str__(self):
         return self.name or "Без названия"
+
+
+class WorkAssignmentSubtask(models.Model):
+    work_assignment = models.ForeignKey(
+        "WorkAssignment",
+        on_delete=models.CASCADE,
+        related_name="subtasks",
+        verbose_name="Рабочее задание",
+    )
+    subtask_number = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+        editable=False,
+        verbose_name="Порядковый номер в рамках РЗ",
+    )
+    category = models.CharField(max_length=100, default="Подзадача", verbose_name="Категория")
+    executor = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        null=True,
+        blank=True,
+        related_name="subtask_executed_assignments",
+        verbose_name="Исполнитель",
+    )
+    author = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="subtask_authored_assignments",
+        verbose_name="Автор",
+    )
+    date_of_creation = models.DateTimeField(
+        default=timezone.now, verbose_name="Дата и время создания"
+    )
+    last_editor = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="subtask_edited_assignments",
+        verbose_name="Последний редактор",
+    )
+    date_of_change = models.DateTimeField(auto_now=True, verbose_name="Дата и время последнего изменения")
+    current_responsible = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="subtask_responsible_assignments",
+        verbose_name="Текущий ответственный",
+    )
+    version = models.CharField(max_length=3, blank=True, null=True, verbose_name="Версия")
+    task = models.TextField(verbose_name="Задача")
+    acceptance_criteria = models.TextField(default="---", verbose_name="Критерий выполнения")
+    uploaded_file = models.FileField(
+        upload_to="work_assignment_subtasks/", blank=True, verbose_name="Загружаемый файл"
+    )
+    deadline_version = models.PositiveIntegerField(default=0, verbose_name="Версия дедлайна")
+    reschedule_count = models.PositiveIntegerField(default=0, verbose_name="Количество переносов")
+    result = models.CharField(
+        max_length=100,
+        choices=WorkAssignment.RESULT_CHOICES,
+        blank=True,
+        null=True,
+        verbose_name="Результат",
+    )
+    result_description = models.TextField(
+        max_length=5000, blank=True, null=True, verbose_name="Описание результата"
+    )
+    target_deadline = models.DateField("Целевой срок выполнения", default=timezone.now)
+    hard_deadline = models.DateField("Абсолютный дедлайн", null=True, blank=True)
+    time_window_start = models.DateField("Временное окно: с", null=True, blank=True)
+    time_window_end = models.DateField("Временное окно: по", null=True, blank=True)
+    conditional_deadline = models.CharField("Условный дедлайн", max_length=1000, blank=True)
+    control_status = models.CharField(
+        "Контроль выполнения - статус",
+        max_length=20,
+        null=True,
+        blank=True,
+        choices=WorkAssignment.TEMP_STATUS_CHOICES,
+    )
+    control_date = models.DateField("Дата фиксации статуса", null=True, blank=True)
+
+    class Meta:
+        verbose_name = "Подзадача рабочего задания"
+        verbose_name_plural = "Подзадачи рабочих заданий"
+        ordering = ("work_assignment_id", "subtask_number", "pk")
+
+    @property
+    def subtask_full_code(self) -> str:
+        wa = self.work_assignment if self.work_assignment_id else None
+        parent_code = getattr(wa, "wa_full_code", "") if wa else ""
+        if parent_code and self.subtask_number:
+            return f"{parent_code}.{self.subtask_number}"
+        return ""
+
+    def clean(self):
+        super().clean()
+        wa = self.work_assignment if self.work_assignment_id else None
+        if wa is None:
+            return
+
+        snapshot = None
+        if self.pk:
+            try:
+                snapshot = type(self).objects.values(
+                    "target_deadline", "hard_deadline"
+                ).get(pk=self.pk)
+            except type(self).DoesNotExist:
+                snapshot = None
+
+        if self.target_deadline and wa.target_deadline:
+            changed = snapshot is None or snapshot["target_deadline"] != self.target_deadline
+            if changed and self.target_deadline > wa.target_deadline:
+                wa_label = wa.wa_full_code or str(wa)
+                raise ValidationError({
+                    "target_deadline": (
+                        f"Целевой срок подзадачи ({self.target_deadline:%d.%m.%Y}) не может быть позже "
+                        f"целевого срока рабочего задания {wa_label} ({wa.target_deadline:%d.%m.%Y})."
+                    )
+                })
+
+        if self.hard_deadline and wa.hard_deadline:
+            changed = snapshot is None or snapshot["hard_deadline"] != self.hard_deadline
+            if changed and self.hard_deadline > wa.hard_deadline:
+                wa_label = wa.wa_full_code or str(wa)
+                raise ValidationError({
+                    "hard_deadline": (
+                        f"Абсолютный дедлайн подзадачи ({self.hard_deadline:%d.%m.%Y}) не может быть позже "
+                        f"абсолютного дедлайна рабочего задания {wa_label} ({wa.hard_deadline:%d.%m.%Y})."
+                    )
+                })
+
+    def __str__(self):
+        code = self.subtask_full_code
+        head = (self.task or "").strip().replace("\n", " ")[:60]
+        if code:
+            return f"{code}: {head}" if head else code
+        return head or f"Подзадача #{self.pk or 'новая'}"
+
 
 class WorkAssignmentDeadlineChange(models.Model):
     assignment = models.ForeignKey(
@@ -1594,7 +2131,23 @@ class Attachment(models.Model):
 
 
 class RKDDeveloper(models.Model):
+    """Общий справочник для РКД (как «Организация-разработчик»)
+    и для отгрузок (как «Изготовитель/Поставщик»)."""
+
     name = models.CharField(max_length=200, unique=True, verbose_name="Название")
+    inn = models.CharField(
+        max_length=12,
+        blank=True,
+        default="",
+        verbose_name="ИНН",
+        help_text="Только цифры, не более 12 символов.",
+        validators=[
+            RegexValidator(
+                regex=r"^\d{0,12}$",
+                message="ИНН должен содержать только цифры (не более 12).",
+            ),
+        ],
+    )
     charter = models.FileField(
         upload_to="rkd_developer/charter/",
         blank=True,
@@ -1607,53 +2160,48 @@ class RKDDeveloper(models.Model):
         null=True,
         verbose_name="Реквизиты",
     )
-    additional_data = models.FileField(
+
+    class Meta:
+        verbose_name = "Организация-разработчик/изготовитель"
+        verbose_name_plural = "Организации-разработчики/изготовители"
+
+    def __str__(self):
+        return self.name
+
+    def clean(self):
+        super().clean()
+        if self.inn:
+            self.inn = self.inn.strip()
+            if not self.inn.isdigit():
+                raise ValidationError({"inn": "ИНН должен содержать только цифры."})
+            if len(self.inn) > 12:
+                raise ValidationError({"inn": "ИНН не должен превышать 12 цифр."})
+
+
+class RKDDeveloperAdditionalFile(models.Model):
+    """Несколько дополнительных файлов на одну организацию-разработчик/изготовитель."""
+
+    developer = models.ForeignKey(
+        RKDDeveloper,
+        on_delete=models.CASCADE,
+        related_name="additional_files",
+        verbose_name="Организация",
+    )
+    file = models.FileField(
         upload_to="rkd_developer/additional/",
-        blank=True,
-        null=True,
-        verbose_name="Дополнительные данные",
+        verbose_name="Файл",
     )
 
     class Meta:
-        verbose_name = "Организация-разработчик"
-        verbose_name_plural = "Организации-разработчики"
+        verbose_name = "Дополнительный файл организации"
+        verbose_name_plural = "Дополнительные файлы организации"
 
     def __str__(self):
-        return self.name
-
-
-class ShipmentSupplier(models.Model):
-    """Организация-поставщик для отгрузок (те же реквизиты, что у организации-разработчика РКД)."""
-
-    name = models.CharField(max_length=200, unique=True, verbose_name="Название")
-    charter = models.FileField(
-        upload_to="shipment_supplier/charter/",
-        blank=True,
-        null=True,
-        verbose_name="Устав",
-    )
-    requisites = models.FileField(
-        upload_to="shipment_supplier/requisites/",
-        blank=True,
-        null=True,
-        verbose_name="Реквизиты",
-    )
-    additional_data = models.FileField(
-        upload_to="shipment_supplier/additional/",
-        blank=True,
-        null=True,
-        verbose_name="Дополнительные данные",
-    )
-
-    class Meta:
-        verbose_name = "Поставщик"
-        verbose_name_plural = "Поставщики"
-
-    def __str__(self):
-        return self.name
+        return self.file.name if self.file else str(self.pk)
 
 
 class UniversalRKD(models.Model):
+    POSITION_DASH = "-"
     STATUS_CHOICES = [
         ("Зарегистрирован", "Зарегистрирован"),
         ("В разработке", "В разработке"),
@@ -1739,7 +2287,13 @@ class UniversalRKD(models.Model):
     )
 
     name = models.CharField(max_length=100, verbose_name="Наименование")
-    desig_document = models.CharField(max_length=50, verbose_name="Обозначение документа")
+    desig_document = models.CharField(
+        max_length=50,
+        blank=True,
+        null=True,
+        unique=True,
+        verbose_name="Обозначение документа",
+    )
     primary_use = models.CharField(max_length=100, blank=True, default="", verbose_name="Первичное применение")
 
     change_number = models.CharField(max_length=8, verbose_name="Номер изменения")
@@ -1807,6 +2361,11 @@ class UniversalRKD(models.Model):
         blank=True,
         verbose_name="Дата планового пересмотра",
     )
+    review_reminder_days = models.PositiveSmallIntegerField(
+        default=60,
+        verbose_name="Оповещение о пересмотре (дней):",
+        help_text="Укажите, за сколько дней до даты планового пересмотра показывать предупреждение в журнале.",
+    )
     language = models.CharField(
         max_length=3,
         choices=LANGUAGE_CHOICES,
@@ -1844,19 +2403,45 @@ class UniversalRKD(models.Model):
         upload_to="blog/universal_rkd/documents/%Y/%m/",
         blank=True,
         null=True,
-        verbose_name="Документ (загружаемый файл)",
+        verbose_name="Документ: итоговый",
+    )
+    document_source = models.FileField(
+        upload_to="blog/universal_rkd/documents/source/%Y/%m/",
+        blank=True,
+        null=True,
+        verbose_name="Документ: исходник",
     )
     approval_document = models.FileField(
         upload_to="blog/universal_rkd/approval/%Y/%m/",
         blank=True,
         null=True,
-        verbose_name="Лист утверждения",
+        validators=[FileExtensionValidator(allowed_extensions=["pdf"])],
+        verbose_name="Лист утверждения: итоговый (PDF)",
+        help_text="Допустимый формат: PDF.",
+    )
+    approval_source = models.FileField(
+        upload_to="blog/universal_rkd/approval/source/%Y/%m/",
+        blank=True,
+        null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["docx"])],
+        verbose_name="Лист утверждения: исходник (DOCX)",
+        help_text="Допустимый формат: DOCX.",
     )
     attestation_document = models.FileField(
         upload_to="blog/universal_rkd/attestation/%Y/%m/",
         blank=True,
         null=True,
-        verbose_name="Удостоверяющий лист",
+        validators=[FileExtensionValidator(allowed_extensions=["pdf"])],
+        verbose_name="Удостоверяющий лист: итоговый (PDF)",
+        help_text="Допустимый формат: PDF.",
+    )
+    attestation_source = models.FileField(
+        upload_to="blog/universal_rkd/attestation/source/%Y/%m/",
+        blank=True,
+        null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["docx"])],
+        verbose_name="Удостоверяющий лист: исходник (DOCX)",
+        help_text="Допустимый формат: DOCX.",
     )
 
     checked_by = models.ForeignKey(
@@ -1905,10 +2490,6 @@ class UniversalRKD(models.Model):
         ordering = ("post_id", "section_sort_index", "order_in_section", "pk")
         constraints = [
             models.UniqueConstraint(
-                fields=("post", "desig_document"),
-                name="blog_universalrkd_unique_desig_per_post",
-            ),
-            models.UniqueConstraint(
                 fields=("post", "name"),
                 name="blog_universalrkd_unique_name_per_post",
             ),
@@ -1923,6 +2504,21 @@ class UniversalRKD(models.Model):
             raise ValidationError({"name": "Укажите наименование."})
         if not (self.desig_document or "").strip():
             raise ValidationError({"desig_document": "Укажите обозначение документа."})
+
+        dg = (self.desig_document or "").strip()
+        qs_des = UniversalRKD.objects.filter(desig_document=dg)
+        if self.pk:
+            qs_des = qs_des.exclude(pk=self.pk)
+        if qs_des.exists():
+            raise ValidationError(
+                {
+                    "desig_document": (
+                        "РКД с таким обозначением документа уже существует. "
+                        "Обозначение должно быть уникальным."
+                    )
+                }
+            )
+
         if self.post_id:
             nm = (self.name or "").strip()
             qs_name = UniversalRKD.objects.filter(post_id=self.post_id, name=nm)
@@ -1934,16 +2530,7 @@ class UniversalRKD(models.Model):
                         "name": "В этой разработке уже есть позиция журнала с таким наименованием."
                     }
                 )
-            dg = (self.desig_document or "").strip()
-            qs_des = UniversalRKD.objects.filter(post_id=self.post_id, desig_document=dg)
-            if self.pk:
-                qs_des = qs_des.exclude(pk=self.pk)
-            if qs_des.exists():
-                raise ValidationError(
-                    {
-                        "desig_document": "В этой разработке уже есть позиция с таким обозначением документа."
-                    }
-                )
+
         section = self.specification_section or ""
         allowed = allowed_categories_for_section(section)
         if not section_has_category_choices(section):
@@ -1962,23 +2549,47 @@ class UniversalRKD(models.Model):
                         )
                     }
                 )
-        if self.status and self.status != "Зарегистрирован" and not self.document_uploaded_file:
+        if not section_allows_position(section):
+            self.position = self.POSITION_DASH
+        else:
+            self.position = (self.position or "").strip()
+            if not self.position:
+                raise ValidationError({"position": "Укажите позицию."})
+            if self.post_id:
+                qs_pos = UniversalRKD.objects.filter(
+                    post_id=self.post_id,
+                    position=self.position,
+                )
+                if self.pk:
+                    qs_pos = qs_pos.exclude(pk=self.pk)
+                if qs_pos.exists():
+                    raise ValidationError(
+                        {
+                            "position": (
+                                "В этой разработке уже есть позиция журнала "
+                                "с таким номером."
+                            )
+                        }
+                    )
+        if (
+            self.status
+            and self.status != "Зарегистрирован"
+            and not self.document_uploaded_file
+            and not self.document_source
+        ):
             raise ValidationError(
-                {"document_uploaded_file": "Загрузите документ для статуса, отличного от «Зарегистрирован»."}
+                {
+                    "document_uploaded_file": (
+                        "Загрузите документ (итоговый PDF или исходник DOCX) "
+                        "для статуса, отличного от «Зарегистрирован»."
+                    )
+                }
             )
         if self.status == "Выпущен":
             if not self.checked_by:
                 raise ValidationError({"checked_by": "Для статуса «Выпущен» укажите проверившего."})
             if not self.signature_checked:
                 raise ValidationError({"signature_checked": "Для статуса «Выпущен» приложите подпись проверки."})
-        if self.validity_date and (not self.signature_checked or not self.signature_approved):
-            raise ValidationError(
-                {
-                    "validity_date": (
-                        "Дату планового пересмотра можно указать только при наличии подписей проверки и утверждения."
-                    ),
-                }
-            )
 
     def save(self, *args, **kwargs):
         if self.post_id:
@@ -2015,12 +2626,20 @@ class Shipment(models.Model):
         null=True,
         verbose_name="Паспорт/Формуляр",
     )
-    supplier = models.ForeignKey(
-        "ShipmentSupplier",
+    manufacturer_org = models.ForeignKey(
+        "RKDDeveloper",
         on_delete=models.PROTECT,
         null=True,
         blank=True,
-        related_name="shipments",
+        related_name="shipments_manufacturer",
+        verbose_name="Изготовитель",
+    )
+    supplier_org = models.ForeignKey(
+        "RKDDeveloper",
+        on_delete=models.PROTECT,
+        null=True,
+        blank=True,
+        related_name="shipments_supplier",
         verbose_name="Поставщик",
     )
     shipment_date = models.DateField(
@@ -2028,13 +2647,21 @@ class Shipment(models.Model):
         blank=True,
         verbose_name="Дата отгрузки",
     )
+    buyer = models.ForeignKey(
+        "crm.Customer",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="shipments_buyers",
+        verbose_name="Покупатель",
+    )
     recipient = models.ForeignKey(
         "crm.Customer",
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="shipments",
-        verbose_name="Получатель",
+        verbose_name="Грузополучатель",
     )
     completeness = models.TextField(
         max_length=5000,
@@ -2082,8 +2709,8 @@ class Shipment(models.Model):
     )
 
     class Meta:
-        verbose_name = "Отгрузка"
-        verbose_name_plural = "Отгрузки"
+        verbose_name = "Изделие к отгрузке"
+        verbose_name_plural = "Изделия к отгрузке"
         ordering = ("post", "manufacture_date", "serial_number", "pk")
         constraints = [
             models.UniqueConstraint(

--- a/blog/static/blog/js/universal_rkd_category.js
+++ b/blog/static/blog/js/universal_rkd_category.js
@@ -5,6 +5,35 @@
 (function () {
   "use strict";
 
+  var POSITION_EDITABLE_SECTIONS = new Set([
+    "assembly_units",
+    "parts",
+    "standard_products",
+    "other_products",
+    "materials",
+  ]);
+
+  function sectionAllowsPosition(sectionCode) {
+    return POSITION_EDITABLE_SECTIONS.has(sectionCode || "");
+  }
+
+  function syncPosition(sectionSelect) {
+    var sectionCode = sectionSelect.value || "";
+    var posName = sectionSelect.name.replace(/specification_section$/, "position");
+    var root = sectionSelect.form || document;
+    var pos = root.querySelector("[name=" + JSON.stringify(posName) + "]");
+    if (!pos || (pos.tagName !== "INPUT" && pos.tagName !== "TEXTAREA")) return;
+
+    if (sectionAllowsPosition(sectionCode)) {
+      pos.disabled = false;
+      if (pos.value === "-") pos.value = "";
+      return;
+    }
+
+    pos.value = "-";
+    pos.disabled = true;
+  }
+
   function categoryMap() {
     var el = document.getElementById("rkd-category-by-section");
     if (!el || !el.textContent) return {};
@@ -46,6 +75,8 @@
     } else {
       cat.value = "";
     }
+
+    syncPosition(sectionSelect);
   }
 
   function syncAll() {

--- a/templates/admin/blog/productgroup/change_list.html
+++ b/templates/admin/blog/productgroup/change_list.html
@@ -1,0 +1,17 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <style>
+    #changelist #result_list td {
+      max-width: 22rem;
+      white-space: normal;
+      word-break: break-word;
+      vertical-align: top;
+    }
+    #changelist #result_list th {
+      vertical-align: top;
+    }
+  </style>
+{% endblock %}

--- a/templates/admin/blog/technicalproposaldocument/change_form.html
+++ b/templates/admin/blog/technicalproposaldocument/change_form.html
@@ -1,0 +1,14 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; {% if has_view_permission %}<a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>{% else %}{{ opts.verbose_name_plural|capfirst }}{% endif %}
+{% if tp_breadcrumb_post %}
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}?post__id__exact={{ tp_breadcrumb_post.pk }}">{{ tp_breadcrumb_post.name }}</a>
+{% endif %}
+&rsaquo; {% if add %}{% blocktranslate with name=opts.verbose_name %}Add {{ name }}{% endblocktranslate %}{% else %}{% if tp_breadcrumb_record_title %}{{ tp_breadcrumb_record_title }}{% else %}{{ original|truncatewords:"18" }}{% endif %}{% endif %}
+</div>
+{% endblock %}

--- a/templates/admin/blog/technicalproposaldocument/change_list.html
+++ b/templates/admin/blog/technicalproposaldocument/change_list.html
@@ -1,0 +1,36 @@
+{% extends "admin/change_list.html" %}
+{% load i18n admin_urls %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <style>
+    .tp-changelist-headings .tp-changelist-supertitle {
+      margin: 0 0 0.35rem 0;
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--body-quiet-color, #747474);
+    }
+    .tp-changelist-headings h1 {
+      margin-top: 0;
+    }
+  </style>
+{% endblock %}
+
+{% block content_title %}
+  <header class="tp-changelist-headings">
+    <p class="tp-changelist-supertitle">Электронная структура технического предложения</p>
+    <h1>Выберите документ ПТ для изменения</h1>
+  </header>
+{% endblock %}
+{% block content_subtitle %}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=cl.opts.app_label %}">{{ cl.opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url cl.opts|admin_urlname:'changelist' %}">{{ cl.opts.verbose_name_plural|capfirst }}</a>
+{% if tp_breadcrumb_post %}
+&rsaquo; {{ tp_breadcrumb_post.name }}
+{% endif %}
+</div>
+{% endblock %}

--- a/templates/admin/blog/universal_rkd_category_change_form.html
+++ b/templates/admin/blog/universal_rkd_category_change_form.html
@@ -17,4 +17,94 @@
 {{ rkd_category_by_section_dict|json_script:"rkd-category-by-section" }}
 {% endif %}
 <script src="{% static 'blog/js/universal_rkd_category.js' %}"></script>
+{% if product_group_data_url_template %}
+<script>
+(function () {
+    "use strict";
+
+    var DATA_URL_TPL = "{{ product_group_data_url_template }}";
+
+    function setSpan(spanId, value) {
+        var el = document.getElementById(spanId);
+        if (!el) { return; }
+        el.textContent = value && value.trim().length ? value : "—";
+    }
+
+    function setMainPurposeIfEmpty(value) {
+        var el = document.getElementById("id_main_purpose");
+        if (!el || (el.value || "").trim()) { return; }
+        if (value) { el.value = value; }
+    }
+
+    function fetchGroupAndFill(pk) {
+        if (!pk) { return; }
+        var url = DATA_URL_TPL.replace(/\/0\/?$/, "/" + pk + "/");
+        fetch(url, { credentials: "same-origin" })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                if (!data || !data.ok) { return; }
+                setSpan("pg_val_name", data.name);
+                setSpan("pg_val_designation", data.designation);
+                setMainPurposeIfEmpty(data.main_purpose);
+            })
+            .catch(function () {});
+    }
+
+    function clearGroupSpans() {
+        setSpan("pg_val_name", "");
+        setSpan("pg_val_designation", "");
+    }
+
+    function applyGroupSelectState(checked, $groupSelect) {
+        var wrapper = $groupSelect[0].closest(".related-widget-wrapper") || $groupSelect[0].parentElement;
+        if (checked) {
+            $groupSelect.prop("disabled", false);
+            if (wrapper) { wrapper.style.opacity = "1"; }
+        } else {
+            $groupSelect.val(null).trigger("change.select2");
+            $groupSelect.prop("disabled", true);
+            if (wrapper) { wrapper.style.opacity = "0.5"; }
+            clearGroupSpans();
+        }
+    }
+
+    /* Ждём, пока django.jQuery и Select2 инициализируются */
+    function init() {
+        var $ = window.django && window.django.jQuery;
+        if (!$) { return; }
+
+        var $checkbox = $("#id_is_group_modification");
+        var $groupSelect = $("#id_product_group");
+        if (!$checkbox.length || !$groupSelect.length) { return; }
+
+        applyGroupSelectState($checkbox.prop("checked"), $groupSelect);
+        if ($checkbox.prop("checked") && $groupSelect.val()) {
+            fetchGroupAndFill($groupSelect.val());
+        }
+
+        $checkbox.on("change", function () {
+            var checked = $checkbox.prop("checked");
+            applyGroupSelectState(checked, $groupSelect);
+            if (checked && $groupSelect.val()) {
+                fetchGroupAndFill($groupSelect.val());
+            }
+        });
+
+        /* Select2 стреляет нативным change; ловим его через jQuery */
+        $groupSelect.on("change", function () {
+            if (!$checkbox.prop("checked")) { return; }
+            var pk = $groupSelect.val() || "";
+            if (pk) { fetchGroupAndFill(pk); } else { clearGroupSpans(); }
+        });
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        /* DOMContentLoaded уже прошёл, но Select2 мог ещё не инициализироваться */
+        setTimeout(init, 0);
+    }
+})();
+</script>
+{% endif %}
 {% endblock %}

--- a/templates/admin/blog/workassignment/change_form.html
+++ b/templates/admin/blog/workassignment/change_form.html
@@ -11,7 +11,104 @@
 
 {% block extrahead %}
   {{ block.super }}
+  <style>
+    #subtasks-group .form-row.has_original td.original p {
+      display: none !important;
+    }
+    #subtasks-group .inline-group table {
+      table-layout: auto;
+      width: 100%;
+    }
+    #subtasks-group td.field-task_preview,
+    #subtasks-group td.field-criteria_preview {
+      vertical-align: top;
+    }
+    #subtasks-group .subtask-inline-cell {
+      white-space: normal;
+      word-break: break-word;
+      overflow-wrap: anywhere;
+      max-width: 22rem;
+      min-width: 9rem;
+      line-height: 1.4;
+    }
+  </style>
   <script>
+    (function () {
+      var POPUP_NAME_PREFIX = "subtask_popup_";
+      var SUBTASK_PATH_RE = /\/admin\/blog\/workassignmentsubtask\//;
+
+      function isSubtaskPopup(win) {
+        try {
+          if (!win) return false;
+          if (typeof win.name === "string" && win.name.indexOf(POPUP_NAME_PREFIX) === 0) return true;
+          if (win.location && SUBTASK_PATH_RE.test(win.location.pathname || "")) return true;
+        } catch (e) {}
+        return false;
+      }
+      function wrapDismiss(name) {
+        var prev = window[name];
+        window[name] = function (win) {
+          if (isSubtaskPopup(win)) {
+            try { win.close(); } catch (e) {}
+            window.location.reload();
+            return;
+          }
+          if (typeof prev === "function") {
+            return prev.apply(this, arguments);
+          }
+        };
+      }
+      wrapDismiss("dismissAddRelatedObjectPopup");
+      wrapDismiss("dismissChangeRelatedObjectPopup");
+      wrapDismiss("dismissDeleteRelatedObjectPopup");
+
+      document.addEventListener("DOMContentLoaded", function () {
+        var match = window.location.pathname.match(/\/workassignment\/(\d+)\//);
+        var parentPk = match ? match[1] : null;
+
+        function openPopup(url) {
+          var sep = url.indexOf("?") >= 0 ? "&" : "?";
+          if (url.indexOf("_popup=1") < 0) url += sep + "_popup=1";
+          var name = POPUP_NAME_PREFIX + Date.now();
+          var w = window.open(
+            url,
+            name,
+            "width=1100,height=820,scrollbars=yes,resizable=yes"
+          );
+          return w;
+        }
+
+        var group = document.getElementById("subtasks-group");
+        if (group) {
+          var addBtn = document.createElement("a");
+          addBtn.href = "#";
+          addBtn.className = "addlink";
+          addBtn.id = "add-subtask-btn";
+          addBtn.style.display = "inline-block";
+          addBtn.style.marginTop = "8px";
+          addBtn.textContent = "Добавить подзадачу";
+          if (!parentPk) {
+            addBtn.style.opacity = "0.5";
+            addBtn.style.pointerEvents = "none";
+            addBtn.title = "Сначала сохраните рабочее задание";
+          }
+          addBtn.addEventListener("click", function (e) {
+            e.preventDefault();
+            if (!parentPk) return;
+            openPopup("/admin/blog/workassignmentsubtask/add/?work_assignment=" + parentPk);
+          });
+          group.appendChild(addBtn);
+        }
+
+        document.addEventListener("click", function (e) {
+          var a = e.target.closest("a.subtask-open-link");
+          if (!a) return;
+          e.preventDefault();
+          openPopup(a.getAttribute("href"));
+        });
+      });
+    })();
+
     document.addEventListener("DOMContentLoaded", function () {
       var form =
         document.querySelector("#workassignment_form") ||
@@ -54,11 +151,16 @@
       if (!link) return;
 
       var row =
+        document.querySelector(".form-row.field-target_deadline_display") ||
+        document.querySelector(".fieldBox.field-target_deadline_display") ||
         document.querySelector(".form-row.field-target_deadline") ||
         document.querySelector(".fieldBox.field-target_deadline");
       if (!row) return;
 
-      var target = row.querySelector("input, select, textarea") || row;
+      var target =
+        row.querySelector("input, select, textarea") ||
+        row.querySelector(".readonly") ||
+        row;
 
       var moved = link.cloneNode(true);
       moved.removeAttribute("id");


### PR DESCRIPTION
Added ProductGroup (catalog fields, audit fields, optional PDF/source document attachments with user-defined titles, PDF-only column in changelist). Extended Post (product/group identity fields, link from changelist to filtered ProductGroup admin, shipment picker, lifecycle-block cleanup per scope). WorkAssignment refinements (subtasks workflow and control/status labeling from agreed scope). Shipment: split manufacturer vs supplier (RKDDeveloper FKs), buyer/consignee labeling kept; 