### PR TITLE
Update-1.0034-from-15-06-2026 - (Approvals: personal cabinet, LU/LO PDF generation, CAdES signing, RKD/QMS/orders workflow)

### DIFF
--- a/approvals/admin.py
+++ b/approvals/admin.py
@@ -1,0 +1,950 @@
+import base64
+
+from django.contrib import admin, messages
+from django.core.exceptions import PermissionDenied
+from django.db.models import Q
+from django.http import FileResponse, Http404, HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import path, reverse
+from django.utils import timezone
+from django.utils.html import format_html, format_html_join
+
+from .admin_forms import RejectTaskForm, StartApprovalForm
+from .apps import GROUP_ADMIN
+from .document_types import (
+    DOCUMENT_TYPE_FILTER_CHOICES,
+    get_config_by_key,
+    get_config_for_document,
+    get_config_for_process,
+    get_document_from_process,
+    processes_for_user_q,
+    resolve_documents,
+    task_doc_context,
+    user_can_view_process,
+)
+from .models import (
+    Department,
+    DepartmentMember,
+    Vacation,
+    ApprovalRoute,
+    ApprovalRouteStep,
+    ApprovalProcess,
+    ApprovalTask,
+    Notification,
+)
+from .services import ApprovalEngine
+
+
+def is_approval_admin(user):
+    return user.groups.filter(name=GROUP_ADMIN).exists()
+
+
+class ProcessDocumentTypeFilter(admin.SimpleListFilter):
+    title = "Тип документа"
+    parameter_name = "document_type"
+
+    def lookups(self, request, model_admin):
+        return DOCUMENT_TYPE_FILTER_CHOICES
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if not value:
+            return queryset
+        cfg = get_config_by_key(value)
+        ct = cfg.get_content_type()
+        if value == "rkd":
+            return queryset.filter(Q(content_type=ct) | Q(rkd__isnull=False)).distinct()
+        return queryset.filter(content_type=ct)
+
+
+class ProcessRouteActionFilter(admin.SimpleListFilter):
+    title = "Тип шага маршрута"
+    parameter_name = "route_action"
+
+    def lookups(self, request, model_admin):
+        return (
+            (ApprovalRouteStep.ACTION_SIGN, "Согласование / подпись"),
+            (ApprovalRouteStep.ACTION_ACK, "Ознакомление"),
+        )
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if not value:
+            return queryset
+        return queryset.filter(
+            tasks__step__action_type=value,
+            tasks__kind=ApprovalTask.KIND_REVIEW,
+        ).distinct()
+
+
+def _task_has_signature(task):
+    return bool(task.signature_b64) or bool(task.signature_file)
+
+
+def _eds_download_links(task):
+    sig_url = reverse(
+        "admin:approvals_approvalprocess_download_sig",
+        args=[task.process_id, task.pk],
+    )
+    payload_url = reverse(
+        "admin:approvals_approvalprocess_download_payload",
+        args=[task.process_id, task.pk],
+    )
+    return format_html(
+        '<a href="{}" target="_blank" style="font-weight:600;">Скачать .sig</a>'
+        ' &nbsp;|&nbsp; '
+        '<a href="{}" target="_blank">Скачать подписанный файл</a>',
+        sig_url, payload_url,
+    )
+
+
+class _AdminOnlyMixin:
+    def has_module_permission(self, request):
+        return is_approval_admin(request.user)
+
+    def has_view_permission(self, request, obj=None):
+        return is_approval_admin(request.user)
+
+    def has_add_permission(self, request):
+        return is_approval_admin(request.user)
+
+    def has_change_permission(self, request, obj=None):
+        return is_approval_admin(request.user)
+
+    def has_delete_permission(self, request, obj=None):
+        return is_approval_admin(request.user)
+
+
+class DepartmentMemberInline(admin.TabularInline):
+    model = DepartmentMember
+    extra = 1
+    autocomplete_fields = ("user",)
+    verbose_name = "Сотрудник отдела"
+    verbose_name_plural = "Сотрудники (главный + заместители по очереди)"
+
+
+@admin.register(Department)
+class DepartmentAdmin(_AdminOnlyMixin, admin.ModelAdmin):
+    list_display = ("name", "code", "members_preview", "is_active")
+    list_filter = ("is_active",)
+    search_fields = ("name", "code")
+    inlines = [DepartmentMemberInline]
+
+    @admin.display(description="Состав")
+    def members_preview(self, obj):
+        parts = []
+        for m in obj.members.select_related("user").order_by("-is_main", "order"):
+            role = "главный" if m.is_main else f"зам.{m.order}"
+            parts.append(f"{m.user} ({role})")
+        return ", ".join(parts) or "—"
+
+
+@admin.register(Vacation)
+class VacationAdmin(_AdminOnlyMixin, admin.ModelAdmin):
+    list_display = ("user", "start_date", "end_date", "reason")
+    list_filter = ("start_date", "end_date")
+    search_fields = ("user__username", "user__last_name", "reason")
+    autocomplete_fields = ("user",)
+
+
+class ApprovalRouteStepInline(admin.TabularInline):
+    model = ApprovalRouteStep
+    extra = 1
+    verbose_name = "Шаг маршрута"
+    verbose_name_plural = "Шаги маршрута (по порядку)"
+
+
+@admin.register(ApprovalRoute)
+class ApprovalRouteAdmin(_AdminOnlyMixin, admin.ModelAdmin):
+    list_display = ("name", "steps_preview", "is_active")
+    list_filter = ("is_active",)
+    search_fields = ("name", "description")
+    inlines = [ApprovalRouteStepInline]
+
+    @admin.display(description="Маршрут")
+    def steps_preview(self, obj):
+        steps = obj.steps.select_related("department").order_by("order")
+        if not steps:
+            return "—"
+        return " → ".join(str(s.department) for s in steps)
+
+
+class ApprovalTaskInline(admin.TabularInline):
+    model = ApprovalTask
+    extra = 0
+    can_delete = False
+    fields = (
+        "kind", "department", "assigned_to", "status", "is_recheck",
+        "eds_info", "eds_download", "comment", "created_at", "resolved_at",
+    )
+    readonly_fields = fields
+    verbose_name = "Задача"
+    verbose_name_plural = "История задач"
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+    @admin.display(description="ЭЦП")
+    def eds_info(self, obj):
+        if not _task_has_signature(obj):
+            return "—"
+        parts = []
+        if obj.signer_cn:
+            parts.append(obj.signer_cn)
+        if obj.signer_cert_issuer:
+            parts.append(f"УЦ: {obj.signer_cert_issuer}")
+        if obj.signer_cert_valid_to:
+            parts.append(f"до {obj.signer_cert_valid_to}")
+        return " · ".join(parts) if parts else "Подписано"
+
+    @admin.display(description="Скачать")
+    def eds_download(self, obj):
+        if not _task_has_signature(obj):
+            return "—"
+        return _eds_download_links(obj)
+
+
+@admin.register(ApprovalProcess)
+class ApprovalProcessAdmin(admin.ModelAdmin):
+    list_display = (
+        "document_link", "document_type_display", "route", "status_display", "current_order",
+        "eds_count", "started_by", "created_at",
+    )
+    list_filter = ("status", "route", ProcessDocumentTypeFilter, ProcessRouteActionFilter)
+    search_fields = (
+        "rkd__name", "rkd__desig_document",
+        "object_id",
+    )
+    inlines = [ApprovalTaskInline]
+    actions = ["cancel_action"]
+    fieldsets = (
+        ("Согласование", {
+            "fields": (
+                "content_type", "object_id", "rkd", "route", "status",
+                "current_order", "started_by", "created_at", "finished_at",
+            ),
+        }),
+        ("Электронные подписи (ЭЦП)", {
+            "description": (
+                "Файлы для проверки подлинности подписи. "
+                "Для проверки в КриптоПро нужны оба файла: .sig и подписанный документ."
+            ),
+            "fields": ("eds_signatures_block",),
+        }),
+    )
+
+    def has_module_permission(self, request):
+        return request.user.is_authenticated
+
+    def has_view_permission(self, request, obj=None):
+        return request.user.is_authenticated
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return is_approval_admin(request.user)
+
+    def has_delete_permission(self, request, obj=None):
+        return is_approval_admin(request.user)
+
+    def get_readonly_fields(self, request, obj=None):
+        names = [f.name for f in self.model._meta.fields]
+        names.append("eds_signatures_block")
+        return names
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request).select_related(
+            "rkd", "route", "started_by", "content_type",
+        )
+        if is_approval_admin(request.user):
+            return qs
+        return qs.filter(processes_for_user_q(request.user)).distinct()
+
+    @admin.display(description="Документ")
+    def document_link(self, obj):
+        doc = get_document_from_process(obj)
+        if doc is None:
+            return "—"
+        cfg = get_config_for_process(obj)
+        if cfg is None:
+            return str(doc)
+        return format_html(
+            '<a href="{}">{}: {}</a>',
+            cfg.get_admin_url(doc),
+            cfg.label,
+            cfg.get_title(doc),
+        )
+
+    @admin.display(description="Тип")
+    def document_type_display(self, obj):
+        cfg = get_config_for_process(obj)
+        return cfg.label if cfg else "—"
+
+    @admin.display(description="Документ РКД", ordering="rkd")
+    def rkd_link(self, obj):
+        return self.document_link(obj)
+
+    @admin.display(description="ЭЦП")
+    def eds_count(self, obj):
+        signed = [t for t in obj.tasks.all() if _task_has_signature(t)]
+        if not signed:
+            return "—"
+        url = reverse("admin:approvals_approvalprocess_change", args=[obj.pk])
+        n = len(signed)
+        word = "подпись" if n == 1 else ("подписи" if n < 5 else "подписей")
+        return format_html('<a href="{}">{} {}</a>', url, n, word)
+
+    @admin.display(description="Архив ЭЦП")
+    def eds_signatures_block(self, obj):
+        if obj is None:
+            return "—"
+        signed = [
+            t for t in obj.tasks.select_related("department", "assigned_to").order_by("resolved_at", "pk")
+            if _task_has_signature(t)
+        ]
+        if not signed:
+            return format_html(
+                '<p style="color:#888;margin:0;">Подписей ЭЦП по этому согласованию пока нет.</p>'
+            )
+
+        rows = []
+        for t in signed:
+            who = t.assigned_to or "—"
+            dept = t.department or "—"
+            cert = " · ".join(filter(None, [
+                t.signer_cn or "",
+                f"УЦ: {t.signer_cert_issuer}" if t.signer_cert_issuer else "",
+                f"S/N: {t.signer_cert_serial}" if t.signer_cert_serial else "",
+                f"до {t.signer_cert_valid_to}" if t.signer_cert_valid_to else "",
+            ])) or "Данные сертификата не сохранены"
+            when = t.resolved_at.strftime("%d.%m.%Y %H:%M") if t.resolved_at else "—"
+            rows.append(format_html(
+                "<tr>"
+                "<td style='padding:8px;border:1px solid #ccc;'>{}</td>"
+                "<td style='padding:8px;border:1px solid #ccc;'>{}</td>"
+                "<td style='padding:8px;border:1px solid #ccc;'>{}</td>"
+                "<td style='padding:8px;border:1px solid #ccc;font-size:12px;'>{}</td>"
+                "<td style='padding:8px;border:1px solid #ccc;'>{}</td>"
+                "</tr>",
+                dept, who, when, cert, _eds_download_links(t),
+            ))
+
+        return format_html(
+            "<table style='width:100%;border-collapse:collapse;margin-top:4px;'>"
+            "<thead><tr style='background:#f0f0f0;'>"
+            "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Отдел</th>"
+            "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Подписант</th>"
+            "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Дата</th>"
+            "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Сертификат</th>"
+            "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Файлы</th>"
+            "</tr></thead><tbody>{}</tbody></table>",
+            format_html_join("", "{}", ((r,) for r in rows)),
+        )
+
+    @admin.display(description="Статус")
+    def status_display(self, obj):
+        colors = {
+            ApprovalProcess.STATUS_IN_PROGRESS: "#2196F3",
+            ApprovalProcess.STATUS_APPROVED: "#4CAF50",
+            ApprovalProcess.STATUS_CANCELLED: "#9E9E9E",
+        }
+        color = colors.get(obj.status, "#777")
+        return format_html(
+            '<span style="display:inline-flex;align-items:center;gap:6px;">'
+            '<span style="width:10px;height:10px;border-radius:50%;background:{};'
+            'display:inline-block;"></span>{}</span>',
+            color, obj.get_status_display(),
+        )
+
+    @admin.action(description="Отменить согласование")
+    def cancel_action(self, request, queryset):
+        if not is_approval_admin(request.user):
+            raise PermissionDenied
+        done = 0
+        for process in queryset:
+            try:
+                ApprovalEngine.cancel(process, request.user)
+                done += 1
+            except ValueError as e:
+                self.message_user(request, str(e), level=messages.ERROR)
+        if done:
+            self.message_user(request, f"Отменено согласований: {done}.")
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "start/",
+                self.admin_site.admin_view(self.start_view),
+                name="approvals_approvalprocess_start",
+            ),
+            path(
+                "<int:process_pk>/task/<int:task_pk>/download-sig/",
+                self.admin_site.admin_view(self.download_sig_view),
+                name="approvals_approvalprocess_download_sig",
+            ),
+            path(
+                "<int:process_pk>/task/<int:task_pk>/download-payload/",
+                self.admin_site.admin_view(self.download_payload_view),
+                name="approvals_approvalprocess_download_payload",
+            ),
+        ]
+        return custom + urls
+
+    def _get_signed_task(self, request, process_pk, task_pk):
+        process = get_object_or_404(ApprovalProcess, pk=process_pk)
+        if not is_approval_admin(request.user):
+            if not user_can_view_process(request.user, process, is_admin=False):
+                raise PermissionDenied
+        task = get_object_or_404(ApprovalTask, pk=task_pk, process=process)
+        if not task.signature_b64 and not task.signature_file:
+            raise Http404("Подпись для этой задачи не найдена.")
+        return task
+
+    def download_sig_view(self, request, process_pk, task_pk):
+        task = self._get_signed_task(request, process_pk, task_pk)
+        if task.signature_file:
+            return FileResponse(
+                task.signature_file.open("rb"),
+                as_attachment=True,
+                filename=task.signature_file.name.rsplit("/", 1)[-1],
+                content_type="application/pkcs7-signature",
+            )
+        raw = base64.b64decode(task.signature_b64)
+        filename = f"signature_task_{task.pk}.sig"
+        return HttpResponse(
+            raw,
+            content_type="application/pkcs7-signature",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    def download_payload_view(self, request, process_pk, task_pk):
+        from .sign_utils import SignDocumentError, get_signed_document_for_download, is_file_payload
+
+        task = self._get_signed_task(request, process_pk, task_pk)
+        if is_file_payload(task.signed_payload):
+            try:
+                data, filename, content_type = get_signed_document_for_download(task)
+            except SignDocumentError as exc:
+                raise Http404(str(exc))
+            return HttpResponse(
+                data,
+                content_type=content_type,
+                headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+            )
+        payload = task.signed_payload or ""
+        document = get_document_from_process(task.process)
+        cfg = get_config_for_document(document) if document else None
+        name_part = "doc"
+        if document and cfg:
+            name_part = (cfg.get_center_line(document) or str(document.pk)).replace("/", "_")
+        filename = f"signed_payload_{name_part}_task{task.pk}.txt"
+        return HttpResponse(
+            payload,
+            content_type="text/plain; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+
+    def start_view(self, request):
+        doc_type = (
+            request.GET.get("doc_type")
+            or request.POST.get("doc_type")
+            or "rkd"
+        )
+        raw_ids = (
+            request.GET.get("ids", "")
+            or request.POST.get("ids", "")
+            or request.GET.get("rkd_ids", "")
+            or request.POST.get("rkd_ids", "")
+        )
+        ids = [int(x) for x in raw_ids.split(",") if x.strip().isdigit()]
+        try:
+            cfg = get_config_by_key(doc_type)
+        except ValueError as exc:
+            self.message_user(request, str(exc), level=messages.ERROR)
+            return redirect("admin:approvals_approvalprocess_changelist")
+
+        documents = resolve_documents(doc_type, ids)
+
+        if request.method == "POST":
+            form = StartApprovalForm(request.POST)
+            if form.is_valid():
+                route = form.cleaned_data["route"]
+                started, errors = 0, []
+                for document in documents:
+                    try:
+                        ApprovalEngine.start(document, route, request.user)
+                        started += 1
+                    except ValueError as e:
+                        errors.append(f"{document}: {e}")
+                if started:
+                    self.message_user(request, f"Запущено согласований: {started}.")
+                for err in errors:
+                    self.message_user(request, err, level=messages.ERROR)
+                return redirect("admin:approvals_approvalprocess_changelist")
+        else:
+            form = StartApprovalForm()
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": f"Отправить на согласование — {cfg.label}",
+            "form": form,
+            "documents": documents,
+            "doc_type": doc_type,
+            "doc_type_label": cfg.label,
+            "ids": raw_ids,
+            "opts": self.model._meta,
+        }
+        return render(request, "admin/approvals/start_approval.html", context)
+
+
+@admin.register(ApprovalTask)
+class ApprovalTaskAdmin(admin.ModelAdmin):
+    list_display = (
+        "document_link",
+        "document_type_display",
+        "kind_display",
+        "department",
+        "status_display",
+        "recheck_flag",
+        "created_at",
+        "actions_column",
+    )
+    list_filter = ("status", "kind", "department")
+    search_fields = ("process__rkd__name", "process__rkd__desig_document", "process__object_id")
+    list_select_related = ("process", "process__rkd", "process__content_type", "department", "step")
+
+    def has_module_permission(self, request):
+        return False
+
+    def has_view_permission(self, request, obj=None):
+        return request.user.is_authenticated
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        return is_approval_admin(request.user)
+
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        if is_approval_admin(request.user):
+            return qs
+        return qs.filter(assigned_to=request.user)
+
+    @admin.display(description="Документ")
+    def document_link(self, obj):
+        doc = get_document_from_process(obj.process)
+        if doc is None:
+            return "—"
+        cfg = get_config_for_process(obj.process)
+        if cfg is None:
+            return str(doc)
+        return format_html(
+            '<a href="{}">{}: {}</a>',
+            cfg.get_admin_url(doc),
+            cfg.label,
+            cfg.get_title(doc),
+        )
+
+    @admin.display(description="Тип")
+    def document_type_display(self, obj):
+        cfg = get_config_for_process(obj.process)
+        return cfg.label if cfg else "—"
+
+    @admin.display(description="Документ РКД")
+    def rkd_link(self, obj):
+        return self.document_link(obj)
+
+    @admin.display(description="Тип")
+    def kind_display(self, obj):
+        return obj.get_kind_display()
+
+    @admin.display(description="Статус")
+    def status_display(self, obj):
+        colors = {
+            ApprovalTask.STATUS_PENDING: "#2196F3",
+            ApprovalTask.STATUS_APPROVED: "#4CAF50",
+            ApprovalTask.STATUS_REJECTED: "#E53935",
+            ApprovalTask.STATUS_DONE: "#9C27B0",
+            ApprovalTask.STATUS_CANCELLED: "#9E9E9E",
+        }
+        color = colors.get(obj.status, "#777")
+        return format_html(
+            '<span style="display:inline-flex;align-items:center;gap:6px;">'
+            '<span style="width:10px;height:10px;border-radius:50%;background:{};'
+            'display:inline-block;"></span>{}</span>',
+            color, obj.get_status_display(),
+        )
+
+    @admin.display(description="Повтор")
+    def recheck_flag(self, obj):
+        return "↻" if obj.is_recheck else "—"
+
+    @admin.display(description="Действия")
+    def actions_column(self, obj):
+        can_act = is_approval_admin_or_assignee(self._request, obj)
+        if not can_act or obj.status != ApprovalTask.STATUS_PENDING:
+            if obj.comment:
+                return format_html('<span title="{}">💬 замечание</span>', obj.comment)
+            return "—"
+
+        if obj.kind == ApprovalTask.KIND_REVIEW:
+            sign_url = reverse("admin:approvals_task_sign", args=[obj.pk])
+            is_ack = obj.step and obj.step.action_type == ApprovalRouteStep.ACTION_ACK
+            if is_ack:
+                return format_html(
+                    '<a class="button" href="{}" '
+                    'style="background:#9C27B0;color:#fff;padding:3px 10px;'
+                    'border-radius:4px;text-decoration:none;">Ознакомление (ЭЦП)</a>',
+                    sign_url,
+                )
+            reject_url = reverse("admin:approvals_task_reject", args=[obj.pk])
+            return format_html(
+                '<a class="button" href="{}" '
+                'style="background:#4CAF50;color:#fff;padding:3px 10px;'
+                'border-radius:4px;text-decoration:none;margin-right:4px;">Подписать</a>'
+                '<a class="button" href="{}" '
+                'style="background:#E53935;color:#fff;padding:3px 10px;'
+                'border-radius:4px;text-decoration:none;">Отклонить</a>',
+                sign_url, reject_url,
+            )
+        if obj.kind == ApprovalTask.KIND_FIX:
+            resubmit_url = reverse("admin:approvals_task_resubmit", args=[obj.pk])
+            return format_html(
+                '<a class="button" href="{}" '
+                'style="background:#2196F3;color:#fff;padding:3px 10px;'
+                'border-radius:4px;text-decoration:none;">Отправить на доработку</a>',
+                resubmit_url,
+            )
+        return "—"
+
+    def changelist_view(self, request, extra_context=None):
+        self._request = request
+        return super().changelist_view(request, extra_context)
+
+    def get_urls(self):
+        urls = super().get_urls()
+        custom = [
+            path(
+                "cabinet/",
+                self.admin_site.admin_view(self.cabinet_view),
+                name="approvals_cabinet",
+            ),
+            path(
+                "cabinet/notifications/read-all/",
+                self.admin_site.admin_view(self.notifications_read_all_view),
+                name="approvals_notification_read_all",
+            ),
+            path(
+                "cabinet/notifications/clear-all/",
+                self.admin_site.admin_view(self.notifications_clear_all_view),
+                name="approvals_notification_clear_all",
+            ),
+            path(
+                "cabinet/notifications/<int:pk>/open/",
+                self.admin_site.admin_view(self.notification_open_view),
+                name="approvals_notification_open",
+            ),
+            path(
+                "<int:pk>/approve/",
+                self.admin_site.admin_view(self.approve_view),
+                name="approvals_task_approve",
+            ),
+            path(
+                "<int:pk>/reject/",
+                self.admin_site.admin_view(self.reject_view),
+                name="approvals_task_reject",
+            ),
+            path(
+                "<int:pk>/resubmit/",
+                self.admin_site.admin_view(self.resubmit_view),
+                name="approvals_task_resubmit",
+            ),
+            path(
+                "<int:pk>/sign/",
+                self.admin_site.admin_view(self.sign_view),
+                name="approvals_task_sign",
+            ),
+            path(
+                "<int:pk>/sign/content/",
+                self.admin_site.admin_view(self.sign_content_view),
+                name="approvals_task_sign_content",
+            ),
+            path(
+                "<int:pk>/sign/submit/",
+                self.admin_site.admin_view(self.sign_submit_view),
+                name="approvals_task_sign_submit",
+            ),
+        ]
+        return custom + urls
+
+    def cabinet_view(self, request):
+        from django.db.models import Count
+
+        from blog.models import WorkAssignment
+
+        user = request.user
+        pending = list(
+            ApprovalTask.objects
+            .filter(assigned_to=user, status=ApprovalTask.STATUS_PENDING)
+            .select_related("process", "process__rkd", "process__content_type", "department", "step")
+        )
+        sign_tasks, ack_tasks, fix_tasks = [], [], []
+        for t in pending:
+            t.doc_ctx = task_doc_context(t)
+            if t.kind == ApprovalTask.KIND_FIX:
+                fix_tasks.append(t)
+            elif t.step and t.step.action_type == ApprovalRouteStep.ACTION_ACK:
+                ack_tasks.append(t)
+            else:
+                sign_tasks.append(t)
+
+        my_work = list(
+            WorkAssignment.objects
+            .filter(executor=user)
+            .filter(Q(control_status__isnull=True) | Q(control_status="in_progress"))
+            .select_related("post")
+            .order_by("target_deadline")
+        )
+
+        issued_work_qs = (
+            WorkAssignment.objects
+            .filter(author=user)
+            .annotate(subtask_total=Count("subtasks"))
+            .select_related("executor", "post", "current_responsible")
+            .order_by("-date_of_creation")
+        )
+        issued_work = list(issued_work_qs[:50])
+        issued_work_active = issued_work_qs.filter(
+            Q(control_status__isnull=True) | Q(control_status="in_progress")
+        ).count()
+
+        notifications = list(Notification.objects.filter(recipient=user)[:50])
+        unread_count = sum(1 for n in notifications if not n.is_read)
+
+        my_docs = list(
+            ApprovalProcess.objects
+            .filter(processes_for_user_q(user))
+            .exclude(status=ApprovalProcess.STATUS_CANCELLED)
+            .select_related("rkd", "route", "content_type")
+            .distinct()[:50]
+        )
+        for p in my_docs:
+            doc = get_document_from_process(p)
+            cfg = get_config_for_process(p)
+            p.doc_ctx = {
+                "type_label": cfg.label if cfg else "Документ",
+                "title": cfg.get_title(doc) if cfg and doc else str(p),
+                "admin_url": cfg.get_admin_url(doc) if cfg and doc else "",
+            }
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Личный кабинет",
+            "sign_tasks": sign_tasks,
+            "ack_tasks": ack_tasks,
+            "fix_tasks": fix_tasks,
+            "my_work": my_work,
+            "issued_work": issued_work,
+            "issued_work_active": issued_work_active,
+            "my_docs": my_docs,
+            "notifications": notifications,
+            "unread_count": unread_count,
+            "today": timezone.localdate(),
+            "opts": self.model._meta,
+        }
+        return render(request, "admin/approvals/cabinet.html", context)
+
+    def notification_open_view(self, request, pk):
+        n = get_object_or_404(Notification, pk=pk, recipient=request.user)
+        if not n.is_read:
+            n.is_read = True
+            n.save(update_fields=["is_read"])
+        return redirect(n.url or reverse("admin:approvals_cabinet"))
+
+    def notifications_read_all_view(self, request):
+        if request.method == "POST":
+            Notification.objects.filter(
+                recipient=request.user, is_read=False
+            ).update(is_read=True)
+        return redirect(reverse("admin:approvals_cabinet"))
+
+    def notifications_clear_all_view(self, request):
+        if request.method == "POST":
+            deleted, _ = Notification.objects.filter(recipient=request.user).delete()
+            if deleted:
+                self.message_user(request, f"Удалено уведомлений: {deleted}.")
+        return redirect(reverse("admin:approvals_cabinet"))
+
+    def _get_task_guarded(self, request, pk):
+        task = get_object_or_404(ApprovalTask, pk=pk)
+        if not is_approval_admin_or_assignee(request, task):
+            raise PermissionDenied
+        return task
+
+    def _back_url(self):
+        return reverse("admin:approvals_approvaltask_changelist")
+
+    def approve_view(self, request, pk):
+        task = self._get_task_guarded(request, pk)
+        if (
+            task.kind == ApprovalTask.KIND_REVIEW
+            and task.status == ApprovalTask.STATUS_PENDING
+        ):
+            return redirect(reverse("admin:approvals_task_sign", args=[pk]))
+        return redirect(self._back_url())
+
+    def resubmit_view(self, request, pk):
+        task = self._get_task_guarded(request, pk)
+        if request.method == "POST":
+            try:
+                ApprovalEngine.resubmit(task, request.user)
+                self.message_user(request, "Документ отправлен на повторную проверку.")
+            except ValueError as e:
+                self.message_user(request, str(e), level=messages.ERROR)
+            return redirect(self._back_url())
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Отправить на доработку",
+            "message": f"Отправить исправленный документ «{task_doc_context(task)['title']}» "
+                       f"на повторную проверку в отдел «{task.department}»?",
+            "action_url": request.path,
+            "back_url": self._back_url(),
+            "opts": self.model._meta,
+        }
+        return render(request, "admin/approvals/confirm_action.html", context)
+
+    def reject_view(self, request, pk):
+        task = self._get_task_guarded(request, pk)
+        if request.method == "POST":
+            form = RejectTaskForm(request.POST)
+            if form.is_valid():
+                try:
+                    ApprovalEngine.reject(task, request.user, form.cleaned_data["comment"])
+                    self.message_user(request, "Задача отклонена, автор получил замечание.")
+                except ValueError as e:
+                    self.message_user(request, str(e), level=messages.ERROR)
+                return redirect(self._back_url())
+        else:
+            form = RejectTaskForm()
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Отклонить с замечанием",
+            "form": form,
+            "task": task,
+            "doc_ctx": task_doc_context(task),
+            "back_url": self._back_url(),
+            "opts": self.model._meta,
+        }
+        return render(request, "admin/approvals/reject_task.html", context)
+
+    def sign_view(self, request, pk):
+        from .sign_utils import SignDocumentError, get_main_document
+
+        task = self._get_task_guarded(request, pk)
+
+        if task.status != ApprovalTask.STATUS_PENDING:
+            self.message_user(request, "Задача уже обработана.", level=messages.WARNING)
+            return redirect(reverse("admin:approvals_cabinet"))
+
+        is_ack = task.step and task.step.action_type == ApprovalRouteStep.ACTION_ACK
+
+        try:
+            document, doc_cfg, main_doc = get_main_document(task.process)
+            sign_filename = main_doc.name.rsplit("/", 1)[-1]
+        except SignDocumentError as exc:
+            self.message_user(request, str(exc), level=messages.ERROR)
+            return redirect(reverse("admin:approvals_cabinet"))
+
+        context = {
+            **self.admin_site.each_context(request),
+            "title": "Ознакомление с документом (ЭЦП)" if is_ack else "Подписание документа (ЭЦП)",
+            "task": task,
+            "document": document,
+            "doc_type_label": doc_cfg.label,
+            "doc_title": doc_cfg.get_title(document),
+            "doc_subtitle": doc_cfg.get_subtitle(document),
+            "doc_file_url": doc_cfg.get_file_url(document),
+            "doc_admin_url": doc_cfg.get_admin_url(document),
+            "is_ack": is_ack,
+            "content_url": reverse("admin:approvals_task_sign_content", args=[pk]),
+            "submit_url": reverse("admin:approvals_task_sign_submit", args=[pk]),
+            "back_url": reverse("admin:approvals_cabinet"),
+            "reject_url": reverse("admin:approvals_task_reject", args=[pk]),
+            "sign_filename": sign_filename,
+            "opts": self.model._meta,
+        }
+        return render(request, "admin/approvals/sign_document.html", context)
+
+    def sign_content_view(self, request, pk):
+        from .sign_utils import SignDocumentError, get_main_document, read_sign_document_bytes
+
+        task = self._get_task_guarded(request, pk)
+        try:
+            data = read_sign_document_bytes(task)
+        except SignDocumentError as exc:
+            return JsonResponse({"error": str(exc)}, status=400)
+        _, doc_cfg, doc = get_main_document(task.process)
+        filename = doc.name.rsplit("/", 1)[-1]
+        content_b64 = base64.b64encode(data).decode("ascii")
+        return JsonResponse({
+            "content_b64": content_b64,
+            "description": f"{doc_cfg.label}: {doc_cfg.get_title(task.process.get_document())}",
+            "filename": filename,
+            "size": len(data),
+        })
+
+    def sign_submit_view(self, request, pk):
+        if request.method != "POST":
+            return JsonResponse({"ok": False, "error": "Метод не поддерживается."}, status=405)
+
+        task = self._get_task_guarded(request, pk)
+
+        if task.status != ApprovalTask.STATUS_PENDING:
+            return JsonResponse({"ok": False, "error": "Задача уже обработана."}, status=400)
+
+        is_ack = task.step and task.step.action_type == ApprovalRouteStep.ACTION_ACK
+
+        sig_b64 = (request.POST.get("signature") or "").strip()
+        if not sig_b64:
+            return JsonResponse({"ok": False, "error": "Подпись не передана."}, status=400)
+
+        try:
+            from .sign_utils import SignDocumentError, read_sign_document_bytes
+            read_sign_document_bytes(task)
+        except SignDocumentError as exc:
+            return JsonResponse({"ok": False, "error": str(exc)}, status=400)
+
+        try:
+            from .sign_utils import parse_cms_signature
+            cert_info = parse_cms_signature(sig_b64)
+        except (ValueError, ImportError) as exc:
+            return JsonResponse({"ok": False, "error": str(exc)}, status=400)
+
+        from .sign_utils import save_task_signature
+
+        save_task_signature(task, sig_b64, cert_info=cert_info)
+
+        try:
+            ApprovalEngine.approve(task, request.user, cert_info=cert_info)
+        except ValueError as exc:
+            return JsonResponse({"ok": False, "error": str(exc)}, status=400)
+
+        return JsonResponse({
+            "ok": True,
+            "message": (
+                f"Ознакомление подтверждено ЭЦП. Сертификат: {cert_info.get('cn', '')}"
+                if is_ack
+                else f"Документ подписан ЭЦП. Сертификат: {cert_info.get('cn', '')}"
+            ),
+            "redirect": reverse("admin:approvals_cabinet"),
+        })
+
+
+def is_approval_admin_or_assignee(request, task):
+    return is_approval_admin(request.user) or task.assigned_to_id == request.user.id

--- a/approvals/admin_forms.py
+++ b/approvals/admin_forms.py
@@ -1,0 +1,18 @@
+from django import forms
+
+from .models import ApprovalRoute
+
+
+class StartApprovalForm(forms.Form):
+    route = forms.ModelChoiceField(
+        queryset=ApprovalRoute.objects.filter(is_active=True),
+        label="Маршрут согласования",
+        empty_label="— выберите маршрут —",
+    )
+
+
+class RejectTaskForm(forms.Form):
+    comment = forms.CharField(
+        label="Замечание для автора",
+        widget=forms.Textarea(attrs={"rows": 5, "cols": 80}),
+    )

--- a/approvals/apps.py
+++ b/approvals/apps.py
@@ -1,0 +1,64 @@
+from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+from django.utils.translation import gettext_lazy as _
+
+
+GROUP_ADMIN = "Согласование: Администратор"
+GROUP_EMPLOYEE = "Согласование: Сотрудник"
+
+
+def _ensure_departments(sender, **kwargs):
+    from .models import Department, SIGNATURE_ROLE_CHOICES
+
+    for role_key, role_label in SIGNATURE_ROLE_CHOICES:
+        Department.objects.get_or_create(
+            name=role_label,
+            defaults={"signature_role": role_key},
+        )
+
+
+def _ensure_groups(sender, **kwargs):
+    from django.contrib.auth.models import Group, Permission
+    from django.contrib.contenttypes.models import ContentType
+    from . import models as m
+
+    admin_group, _ = Group.objects.get_or_create(name=GROUP_ADMIN)
+    employee_group, _ = Group.objects.get_or_create(name=GROUP_EMPLOYEE)
+
+    admin_only_models = [
+        m.Department,
+        m.DepartmentMember,
+        m.Vacation,
+        m.ApprovalRoute,
+        m.ApprovalRouteStep,
+    ]
+    employee_extra_models = [
+        m.ApprovalProcess,
+        m.ApprovalTask,
+        m.Notification,
+    ]
+
+    admin_perms = []
+    for model_cls in admin_only_models + employee_extra_models:
+        ct = ContentType.objects.get_for_model(model_cls)
+        admin_perms.extend(Permission.objects.filter(content_type=ct))
+    admin_group.permissions.set(admin_perms)
+
+    employee_apps = {"blog", "crm", "shared_repository", "enterprise_asset_management"}
+    all_app_perms = list(
+        Permission.objects.filter(content_type__app_label__in=employee_apps)
+    )
+    for model_cls in employee_extra_models:
+        ct = ContentType.objects.get_for_model(model_cls)
+        all_app_perms.extend(Permission.objects.filter(content_type=ct))
+    employee_group.permissions.set(all_app_perms)
+
+
+class ApprovalsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "approvals"
+    verbose_name = _("Согласование документов")
+
+    def ready(self):
+        post_migrate.connect(_ensure_groups, sender=self)
+        post_migrate.connect(_ensure_departments, sender=self)

--- a/approvals/context_processors.py
+++ b/approvals/context_processors.py
@@ -1,0 +1,29 @@
+from django.db.models import Q
+from django.urls import reverse
+
+from .models import ApprovalTask, Notification
+
+
+def cabinet_badge(request):
+    user = getattr(request, "user", None)
+    if not user or not user.is_authenticated:
+        return {}
+
+    tasks_count = ApprovalTask.objects.filter(
+        assigned_to=user, status=ApprovalTask.STATUS_PENDING
+    ).count()
+    unread_count = Notification.objects.filter(
+        recipient=user, is_read=False
+    ).count()
+
+    try:
+        cabinet_url = reverse("admin:approvals_cabinet")
+    except Exception:
+        cabinet_url = ""
+
+    return {
+        "cabinet_url": cabinet_url,
+        "cabinet_tasks_count": tasks_count,
+        "cabinet_unread_count": unread_count,
+        "cabinet_total_count": tasks_count + unread_count,
+    }

--- a/approvals/document_types.py
+++ b/approvals/document_types.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
+from django.urls import reverse
+
+
+@dataclass(frozen=True)
+class DocumentTypeConfig:
+    key: str
+    label: str
+    model_label: str
+    file_field: str
+    author_field: str
+    approval_document_field: str
+    acquaintance_document_field: str
+    admin_url_name: str
+    no_file_message: str
+    approval_filename_prefix: str
+    acquaintance_filename_prefix: str
+    get_center_line: Callable[[Any], str]
+    get_doc_info_lines: Callable[[Any], list[tuple[str, str]]]
+    get_title: Callable[[Any], str]
+    get_subtitle: Callable[[Any], str]
+
+    @property
+    def model(self):
+        return apps.get_model(self.model_label)
+
+    def get_content_type(self):
+        return ContentType.objects.get_for_model(self.model)
+
+    def get_main_file(self, document):
+        return getattr(document, self.file_field, None)
+
+    def has_main_file(self, document) -> bool:
+        f = self.get_main_file(document)
+        return bool(f and getattr(f, "name", None))
+
+    def get_author(self, document):
+        return getattr(document, self.author_field, None)
+
+    def get_admin_url(self, document) -> str:
+        return reverse(self.admin_url_name, args=[document.pk])
+
+    def get_file_url(self, document) -> str:
+        f = self.get_main_file(document)
+        if f and getattr(f, "url", None):
+            return f.url
+        return ""
+
+
+def _rkd_center(doc) -> str:
+    return (doc.desig_document or "—").strip() or "—"
+
+
+def _rkd_info(doc) -> list[tuple[str, str]]:
+    lines = []
+    if doc.post:
+        lines.append(("Разработка (модификация)", str(doc.post)))
+    lines.append(("Обозначение документа", doc.desig_document or "—"))
+    lines.append(("Наименование", doc.name or "—"))
+    return lines
+
+
+def _qms_center(doc) -> str:
+    return (doc.document_title or "—").strip() or "—"
+
+
+def _qms_info(doc) -> list[tuple[str, str]]:
+    category = doc.get_category_display() if doc.category else "—"
+    return [
+        ("Категория", category),
+        ("Название", doc.document_title or "—"),
+        ("Номер изменения", doc.change_number or "—"),
+    ]
+
+
+def _independent_center(doc) -> str:
+    return (doc.document_title or "—").strip() or "—"
+
+
+def _independent_info(doc) -> list[tuple[str, str]]:
+    return [
+        ("Название документа", doc.document_title or "—"),
+        ("Версия", doc.version or "—"),
+    ]
+
+
+def _order_center(doc) -> str:
+    return (doc.registration_number or doc.subject or "—").strip() or "—"
+
+
+def _order_info(doc) -> list[tuple[str, str]]:
+    date_str = doc.order_date.strftime("%d.%m.%Y") if doc.order_date else "—"
+    return [
+        ("Тема", doc.subject or "—"),
+        ("Дата", date_str),
+        ("Регистрационный номер", doc.registration_number or "—"),
+    ]
+
+
+DOCUMENT_TYPES: dict[str, DocumentTypeConfig] = {
+    "rkd": DocumentTypeConfig(
+        key="rkd",
+        label="РКД",
+        model_label="blog.UniversalRKD",
+        file_field="document_uploaded_file",
+        author_field="author",
+        approval_document_field="approval_document",
+        acquaintance_document_field="acquaintance_document",
+        admin_url_name="admin:blog_universalrkd_change",
+        no_file_message=(
+            "Загрузите основной документ (итоговый) в карточке РКД "
+            "перед отправкой на согласование."
+        ),
+        approval_filename_prefix="ЛУ",
+        acquaintance_filename_prefix="ЛО",
+        get_center_line=_rkd_center,
+        get_doc_info_lines=_rkd_info,
+        get_title=lambda d: (d.desig_document or str(d)).strip(),
+        get_subtitle=lambda d: (d.name or "").strip(),
+    ),
+    "qms": DocumentTypeConfig(
+        key="qms",
+        label="Документ СМК",
+        model_label="shared_repository.QMSDocument",
+        file_field="uploaded_file",
+        author_field="author",
+        approval_document_field="approval_document",
+        acquaintance_document_field="acquaintance_document",
+        admin_url_name="admin:shared_repository_qmsdocument_change",
+        no_file_message=(
+            "Загрузите файл в поле «Загружаемый файл» перед отправкой на согласование."
+        ),
+        approval_filename_prefix="ЛУ",
+        acquaintance_filename_prefix="ЛО",
+        get_center_line=_qms_center,
+        get_doc_info_lines=_qms_info,
+        get_title=lambda d: (d.document_title or str(d)).strip(),
+        get_subtitle=lambda d: f"{d.get_category_display()} · изм. {d.change_number or '—'}",
+    ),
+    "independent": DocumentTypeConfig(
+        key="independent",
+        label="Отдельный документ",
+        model_label="shared_repository.SharedRepository",
+        file_field="uploaded_file",
+        author_field="author",
+        approval_document_field="approval_document",
+        acquaintance_document_field="acquaintance_document",
+        admin_url_name="admin:shared_repository_sharedrepository_change",
+        no_file_message=(
+            "Загрузите файл в поле «Загружаемый файл» перед отправкой на согласование."
+        ),
+        approval_filename_prefix="ЛУ",
+        acquaintance_filename_prefix="ЛО",
+        get_center_line=_independent_center,
+        get_doc_info_lines=_independent_info,
+        get_title=lambda d: (d.document_title or str(d)).strip(),
+        get_subtitle=lambda d: f"вер. {d.version or '—'}",
+    ),
+    "order": DocumentTypeConfig(
+        key="order",
+        label="Приказ",
+        model_label="shared_repository.AdministrativeOrder",
+        file_field="uploaded_file",
+        author_field="author",
+        approval_document_field="approval_document",
+        acquaintance_document_field="acquaintance_document",
+        admin_url_name="admin:shared_repository_administrativeorder_change",
+        no_file_message=(
+            "Загрузите файл в поле «Загружаемый файл» перед отправкой на согласование."
+        ),
+        approval_filename_prefix="ЛУ",
+        acquaintance_filename_prefix="ЛО",
+        get_center_line=_order_center,
+        get_doc_info_lines=_order_info,
+        get_title=lambda d: (d.registration_number or str(d)).strip(),
+        get_subtitle=lambda d: (d.subject or "").strip(),
+    ),
+}
+
+DOCUMENT_TYPE_FILTER_CHOICES = [(k, v.label) for k, v in DOCUMENT_TYPES.items()]
+
+
+def get_config_by_key(key: str) -> DocumentTypeConfig:
+    try:
+        return DOCUMENT_TYPES[key]
+    except KeyError as exc:
+        raise ValueError(f"Неизвестный тип документа: {key}") from exc
+
+
+def get_config_for_document(document) -> DocumentTypeConfig:
+    for cfg in DOCUMENT_TYPES.values():
+        if isinstance(document, cfg.model):
+            return cfg
+    raise ValueError(f"Тип документа не поддерживается: {document.__class__.__name__}")
+
+
+def get_config_for_process(process) -> Optional[DocumentTypeConfig]:
+    document = get_document_from_process(process)
+    if document is None:
+        return None
+    return get_config_for_document(document)
+
+
+def get_document_from_process(process):
+    if process.content_type_id and process.object_id:
+        return process.document
+    if process.rkd_id:
+        return process.rkd
+    return None
+
+
+def resolve_documents(doc_type: str, ids: list[int]):
+    cfg = get_config_by_key(doc_type)
+    return list(cfg.model.objects.filter(pk__in=ids))
+
+
+def processes_for_user_q(user) -> Q:
+    q = Q(started_by=user)
+    for cfg in DOCUMENT_TYPES.values():
+        ct = cfg.get_content_type()
+        author_ids = cfg.model.objects.filter(
+            **{cfg.author_field: user}
+        ).values_list("pk", flat=True)
+        q |= Q(content_type=ct, object_id__in=author_ids)
+    q |= Q(rkd__author=user)
+    return q
+
+
+def user_can_view_process(user, process, *, is_admin: bool) -> bool:
+    if is_admin:
+        return True
+    if process.started_by_id == user.id:
+        return True
+    document = get_document_from_process(process)
+    if document is None:
+        return False
+    cfg = get_config_for_document(document)
+    author = cfg.get_author(document)
+    return author is not None and author.id == user.id
+
+
+def task_doc_context(task) -> dict:
+    document = get_document_from_process(task.process)
+    if document is None:
+        return {
+            "type_label": "Документ",
+            "type_key": "",
+            "title": str(task.process),
+            "subtitle": "",
+            "file_url": "",
+            "admin_url": "",
+        }
+    cfg = get_config_for_document(document)
+    subtitle = cfg.get_subtitle(document)
+    return {
+        "type_label": cfg.label,
+        "type_key": cfg.key,
+        "title": cfg.get_title(document) or str(document),
+        "subtitle": subtitle,
+        "file_url": cfg.get_file_url(document),
+        "admin_url": cfg.get_admin_url(document),
+    }
+
+
+def role_label_for_department(department) -> str:
+    if not department:
+        return "—"
+    if department.signature_role:
+        return department.get_signature_role_display()
+    return str(department)

--- a/approvals/models.py
+++ b/approvals/models.py
@@ -1,0 +1,365 @@
+from django.conf import settings
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.utils import timezone
+
+User = settings.AUTH_USER_MODEL
+
+# Роли подписи —
+SIGNATURE_ROLE_CHOICES = [
+    ("designer", "Разработал"),
+    ("scheme", "Проверил (схемотехнические требования)"),
+    ("it", "Проверил IT (требования, связанные с клиент-серверным ПО)"),
+    ("3d", "Проверил 3D (требования, связанные с 3D-печатью)"),
+    ("metro", "Проверил (метрологический контроль)"),
+    ("tk", "Т. контроль (технологический контроль)"),
+    ("lead", "Проверил (руководитель разработки)"),
+    ("nk", "Н. контроль (нормоконтроль)"),
+    ("agreed", "Согласовал"),
+    ("approved", "Утвердил"),
+]
+
+
+class Department(models.Model):
+    name = models.CharField("Название отдела", max_length=150, unique=True)
+    code = models.CharField("Код", max_length=20, blank=True)
+    signature_role = models.CharField(
+        "Роль в листе утверждения",
+        max_length=20,
+        choices=SIGNATURE_ROLE_CHOICES,
+        blank=True,
+        help_text="Под какой ролью подпись этого отдела попадёт в лист утверждения РКД.",
+    )
+    is_active = models.BooleanField("Активен", default=True)
+
+    class Meta:
+        verbose_name = "Отдел"
+        verbose_name_plural = "Отделы"
+        ordering = ("name",)
+
+    def __str__(self):
+        return self.name
+
+
+class DepartmentMember(models.Model):
+    department = models.ForeignKey(
+        Department, on_delete=models.CASCADE,
+        related_name="members", verbose_name="Отдел",
+    )
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        related_name="department_memberships", verbose_name="Сотрудник",
+    )
+    is_main = models.BooleanField("Главный (ответственный)", default=False)
+    order = models.PositiveSmallIntegerField(
+        "Очередь замещения", default=1,
+        help_text="0 — главный; 1, 2, … — заместители по порядку вступления.",
+    )
+
+    class Meta:
+        verbose_name = "Сотрудник отдела"
+        verbose_name_plural = "Сотрудники отделов"
+        unique_together = ("department", "user")
+        ordering = ("department", "-is_main", "order")
+
+    def __str__(self):
+        role = "главный" if self.is_main else f"зам. №{self.order}"
+        return f"{self.user} — {self.department} ({role})"
+
+
+class Vacation(models.Model):
+    user = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        related_name="vacations", verbose_name="Сотрудник",
+    )
+    start_date = models.DateField("С")
+    end_date = models.DateField("По")
+    reason = models.CharField("Причина", max_length=255, blank=True)
+
+    class Meta:
+        verbose_name = "Отпуск / отсутствие"
+        verbose_name_plural = "Отпуска / отсутствия"
+        ordering = ("-start_date",)
+
+    def __str__(self):
+        return f"{self.user}: {self.start_date:%d.%m.%Y}–{self.end_date:%d.%m.%Y}"
+
+    def clean(self):
+        super().clean()
+        if self.start_date and self.end_date and self.end_date < self.start_date:
+            raise ValidationError({"end_date": "Дата «По» не может быть раньше «С»."})
+
+
+class ApprovalRoute(models.Model):
+    name = models.CharField("Название маршрута", max_length=255, unique=True)
+    description = models.CharField("Описание", max_length=500, blank=True)
+    is_active = models.BooleanField("Активен", default=True)
+
+    class Meta:
+        verbose_name = "Маршрут согласования"
+        verbose_name_plural = "Маршруты согласования"
+        ordering = ("name",)
+
+    def __str__(self):
+        return self.name
+
+
+class ApprovalRouteStep(models.Model):
+    ACTION_ACK = "acknowledge"
+    ACTION_SIGN = "sign"
+    ACTION_CHOICES = [
+        (ACTION_ACK, "Ознакомление"),
+        (ACTION_SIGN, "Согласование / Подпись"),
+    ]
+
+    route = models.ForeignKey(
+        ApprovalRoute, on_delete=models.CASCADE,
+        related_name="steps", verbose_name="Маршрут",
+    )
+    order = models.PositiveSmallIntegerField("Порядок", default=1)
+    department = models.ForeignKey(
+        Department, on_delete=models.CASCADE,
+        related_name="route_steps", verbose_name="Отдел",
+    )
+    action_type = models.CharField(
+        "Тип действия", max_length=12,
+        choices=ACTION_CHOICES, default=ACTION_SIGN,
+    )
+
+    class Meta:
+        verbose_name = "Шаг маршрута"
+        verbose_name_plural = "Шаги маршрута"
+        unique_together = ("route", "order")
+        ordering = ("route", "order")
+
+    def __str__(self):
+        return f"{self.order}. {self.department} ({self.get_action_type_display()})"
+
+
+class ApprovalProcess(models.Model):
+    STATUS_IN_PROGRESS = "in_progress"
+    STATUS_APPROVED = "approved"
+    STATUS_CANCELLED = "cancelled"
+    STATUS_CHOICES = [
+        (STATUS_IN_PROGRESS, "В процессе"),
+        (STATUS_APPROVED, "Согласован"),
+        (STATUS_CANCELLED, "Отменён"),
+    ]
+
+    rkd = models.ForeignKey(
+        "blog.UniversalRKD", on_delete=models.CASCADE,
+        related_name="approval_processes", verbose_name="Документ РКД",
+        null=True, blank=True,
+    )
+    content_type = models.ForeignKey(
+        ContentType,
+        on_delete=models.CASCADE,
+        verbose_name="Тип документа",
+        null=True,
+        blank=True,
+    )
+    object_id = models.PositiveIntegerField("ID документа", null=True, blank=True)
+    document = GenericForeignKey("content_type", "object_id")
+    route = models.ForeignKey(
+        ApprovalRoute, on_delete=models.CASCADE,
+        related_name="processes", verbose_name="Маршрут",
+    )
+    status = models.CharField(
+        "Статус", max_length=20,
+        choices=STATUS_CHOICES, default=STATUS_IN_PROGRESS,
+    )
+    current_order = models.PositiveSmallIntegerField("Текущий шаг", default=1)
+    started_by = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True,
+        related_name="started_approvals", verbose_name="Кто запустил",
+    )
+    created_at = models.DateTimeField("Создан", default=timezone.now)
+    finished_at = models.DateTimeField("Завершён", null=True, blank=True)
+
+    class Meta:
+        verbose_name = "Согласование документа"
+        verbose_name_plural = "Согласования документов"
+        ordering = ("-created_at",)
+
+    def __str__(self):
+        from .document_types import get_document_from_process
+        doc = get_document_from_process(self)
+        return f"Согласование «{doc or '—'}» ({self.get_status_display()})"
+
+    def get_document(self):
+        from .document_types import get_document_from_process
+        return get_document_from_process(self)
+
+
+class ApprovalTask(models.Model):
+    KIND_REVIEW = "review"
+    KIND_FIX = "fix"
+    KIND_CHOICES = [
+        (KIND_REVIEW, "Проверка / подписание"),
+        (KIND_FIX, "Доработка автором"),
+    ]
+
+    STATUS_PENDING = "pending"
+    STATUS_APPROVED = "approved"
+    STATUS_REJECTED = "rejected"
+    STATUS_DONE = "done"
+    STATUS_CANCELLED = "cancelled"
+    STATUS_CHOICES = [
+        (STATUS_PENDING, "Ожидает"),
+        (STATUS_APPROVED, "Согласовано"),
+        (STATUS_REJECTED, "Отклонено (замечание)"),
+        (STATUS_DONE, "Отправлено на доработку"),
+        (STATUS_CANCELLED, "Отменено"),
+    ]
+
+    process = models.ForeignKey(
+        ApprovalProcess, on_delete=models.CASCADE,
+        related_name="tasks", verbose_name="Согласование",
+    )
+    step = models.ForeignKey(
+        ApprovalRouteStep, on_delete=models.SET_NULL, null=True, blank=True,
+        related_name="tasks", verbose_name="Шаг маршрута",
+    )
+    department = models.ForeignKey(
+        Department, on_delete=models.SET_NULL, null=True, blank=True,
+        related_name="tasks", verbose_name="Отдел",
+    )
+    kind = models.CharField(
+        "Тип задачи", max_length=10,
+        choices=KIND_CHOICES, default=KIND_REVIEW,
+    )
+    assigned_to = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True,
+        related_name="approval_tasks", verbose_name="Назначено",
+    )
+    status = models.CharField(
+        "Статус", max_length=12,
+        choices=STATUS_CHOICES, default=STATUS_PENDING,
+    )
+    is_recheck = models.BooleanField("Повторная проверка", default=False)
+    comment = models.TextField("Замечание / комментарий", blank=True)
+    parent = models.ForeignKey(
+        "self", on_delete=models.SET_NULL, null=True, blank=True,
+        related_name="children", verbose_name="Связанная задача",
+    )
+    signer_cn = models.CharField("ФИО из сертификата ЭЦП", max_length=500, null=True, blank=True)
+    signer_cert_serial = models.CharField("Серийный № сертификата", max_length=200, null=True, blank=True)
+    signer_cert_valid_to = models.CharField("Сертификат действителен до", max_length=50, null=True, blank=True)
+    signer_cert_issuer = models.CharField("Удостоверяющий центр (УЦ)", max_length=500, null=True, blank=True)
+    signature_b64 = models.TextField("Файл ЭЦП (base64 CAdES)", null=True, blank=True)
+    signature_file = models.FileField(
+        "Файл подписи (.sig)",
+        upload_to="approvals/signatures/%Y/%m/",
+        max_length=500,
+        null=True,
+        blank=True,
+    )
+    signed_payload = models.TextField("Метаданные подписанного файла", null=True, blank=True)
+
+    created_at = models.DateTimeField("Создана", default=timezone.now)
+    viewed_at = models.DateTimeField("Просмотрена", null=True, blank=True)
+    resolved_at = models.DateTimeField("Завершена", null=True, blank=True)
+
+    class Meta:
+        verbose_name = "Задача согласования"
+        verbose_name_plural = "Мои задачи на согласование"
+        ordering = ("-created_at",)
+
+    def __str__(self):
+        return f"{self.get_kind_display()} — {self.process.get_document() or '—'}"
+
+    @property
+    def is_active(self):
+        return self.status == self.STATUS_PENDING
+
+
+class Notification(models.Model):
+    KIND_SIGN = "sign"
+    KIND_ACK = "ack"
+    KIND_FIX = "fix"
+    KIND_WORK = "work"
+    KIND_INFO = "info"
+    KIND_CHOICES = [
+        (KIND_SIGN, "На согласование / подпись"),
+        (KIND_ACK, "На ознакомление"),
+        (KIND_FIX, "На доработку"),
+        (KIND_WORK, "Рабочее задание"),
+        (KIND_INFO, "Информация"),
+    ]
+
+    recipient = models.ForeignKey(
+        User, on_delete=models.CASCADE,
+        related_name="approval_notifications", verbose_name="Получатель",
+    )
+    title = models.CharField("Заголовок", max_length=255)
+    text = models.TextField("Текст", blank=True)
+    url = models.CharField("Ссылка", max_length=500, blank=True)
+    kind = models.CharField(
+        "Тип", max_length=10, choices=KIND_CHOICES, default=KIND_INFO,
+    )
+    is_read = models.BooleanField("Прочитано", default=False)
+    created_at = models.DateTimeField("Создано", default=timezone.now)
+
+    class Meta:
+        verbose_name = "Уведомление"
+        verbose_name_plural = "Уведомления (согласование)"
+        ordering = ("-created_at",)
+
+    def __str__(self):
+        return f"{self.recipient}: {self.title}"
+
+
+class ApprovalSheetRecord(models.Model):
+    """Строка листа утверждения / ознакомления для документов (кроме РКД)."""
+
+    SHEET_APPROVAL = "approval"
+    SHEET_ACQUAINTANCE = "acquaintance"
+    SHEET_CHOICES = [
+        (SHEET_APPROVAL, "Лист утверждения"),
+        (SHEET_ACQUAINTANCE, "Лист ознакомления"),
+    ]
+
+    process = models.ForeignKey(
+        ApprovalProcess,
+        on_delete=models.CASCADE,
+        related_name="sheet_records",
+        verbose_name="Согласование",
+    )
+    task = models.OneToOneField(
+        ApprovalTask,
+        on_delete=models.CASCADE,
+        related_name="sheet_record",
+        verbose_name="Задача",
+    )
+    sheet_type = models.CharField(
+        "Тип листа", max_length=16, choices=SHEET_CHOICES,
+    )
+    content_type = models.ForeignKey(
+        ContentType, on_delete=models.CASCADE, verbose_name="Тип документа",
+    )
+    object_id = models.PositiveIntegerField("ID документа")
+    document = GenericForeignKey("content_type", "object_id")
+    department = models.ForeignKey(
+        Department, on_delete=models.SET_NULL, null=True, blank=True,
+        verbose_name="Отдел",
+    )
+    position = models.CharField("Должность", max_length=150, blank=True)
+    role_label = models.CharField("Роль", max_length=150, blank=True)
+    signed_by = models.ForeignKey(
+        User, on_delete=models.SET_NULL, null=True, blank=True,
+        related_name="approval_sheet_records", verbose_name="Подписант",
+    )
+    signed_at = models.DateField("Дата", null=True, blank=True)
+    cert_cn = models.CharField("ФИО из сертификата ЭЦП", max_length=500, blank=True)
+    cert_issuer = models.CharField("Удостоверяющий центр (УЦ)", max_length=500, blank=True)
+    step_order = models.PositiveSmallIntegerField("Порядок в маршруте", default=0)
+
+    class Meta:
+        verbose_name = "Запись листа согласования"
+        verbose_name_plural = "Записи листов согласования"
+        ordering = ("step_order", "pk")
+
+    def __str__(self):
+        return f"{self.get_sheet_type_display()} — {self.signed_by or '—'}"

--- a/approvals/services.py
+++ b/approvals/services.py
@@ -1,0 +1,761 @@
+from django.contrib.contenttypes.models import ContentType
+
+from django.db import transaction
+
+from django.urls import reverse
+
+from django.utils import timezone
+
+
+
+from .document_types import (
+
+    get_config_for_document,
+
+    get_document_from_process,
+
+    role_label_for_department,
+
+)
+
+from .models import (
+
+    ApprovalProcess,
+
+    ApprovalSheetRecord,
+
+    ApprovalTask,
+
+    DepartmentMember,
+
+    Notification,
+
+    Vacation,
+
+)
+
+
+
+
+
+def notify(recipient, title, *, text="", url="", kind=Notification.KIND_INFO):
+
+    if recipient is None:
+
+        return None
+
+    return Notification.objects.create(
+
+        recipient=recipient, title=title, text=text, url=url, kind=kind,
+
+    )
+
+
+
+
+
+def _cabinet_url():
+
+    return reverse("admin:approvals_cabinet")
+
+
+
+
+
+def is_on_vacation(user, on_date=None):
+
+    if user is None:
+
+        return False
+
+    on_date = on_date or timezone.localdate()
+
+    return Vacation.objects.filter(
+
+        user=user, start_date__lte=on_date, end_date__gte=on_date
+
+    ).exists()
+
+
+
+
+
+def resolve_assignee(department, on_date=None):
+
+    on_date = on_date or timezone.localdate()
+
+    members = list(
+
+        DepartmentMember.objects.filter(department=department)
+
+        .select_related("user")
+
+        .order_by("-is_main", "order")
+
+    )
+
+    if not members:
+
+        return None
+
+    for member in members:
+
+        if not is_on_vacation(member.user, on_date):
+
+            return member.user
+
+    return members[0].user
+
+
+
+
+
+def _document_label(document) -> str:
+
+    cfg = get_config_for_document(document)
+
+    title = cfg.get_title(document)
+
+    return f"{cfg.label}: {title}"
+
+
+
+
+
+class ApprovalEngine:
+
+    @staticmethod
+
+    @transaction.atomic
+
+    def start(document, route, user):
+
+        cfg = get_config_for_document(document)
+
+        ct = ContentType.objects.get_for_model(document)
+
+
+
+        if not route.steps.exists():
+
+            raise ValueError("В выбранном маршруте нет шагов.")
+
+        if ApprovalProcess.objects.filter(
+
+            content_type=ct,
+
+            object_id=document.pk,
+
+            status=ApprovalProcess.STATUS_IN_PROGRESS,
+
+        ).exists():
+
+            raise ValueError("По этому документу уже идёт согласование.")
+
+        if not cfg.has_main_file(document):
+
+            raise ValueError(cfg.no_file_message)
+
+
+
+        empty_depts = []
+
+        for step in route.steps.select_related("department").order_by("order"):
+
+            if not DepartmentMember.objects.filter(department=step.department).exists():
+
+                empty_depts.append(str(step.department))
+
+        if empty_depts:
+
+            raise ValueError(
+
+                f"В отделах нет сотрудников, задача некому назначить: {', '.join(empty_depts)}."
+
+            )
+
+
+
+        first_step = route.steps.order_by("order").first()
+
+        process_kwargs = {
+
+            "content_type": ct,
+
+            "object_id": document.pk,
+
+            "route": route,
+
+            "started_by": user,
+
+            "current_order": first_step.order,
+
+            "status": ApprovalProcess.STATUS_IN_PROGRESS,
+
+        }
+
+        if cfg.key == "rkd":
+
+            process_kwargs["rkd"] = document
+
+
+
+        process = ApprovalProcess.objects.create(**process_kwargs)
+
+        ApprovalEngine._create_review_task(process, first_step)
+
+
+
+        author = cfg.get_author(document)
+
+        doc_label = _document_label(document)
+
+        if author and author != user:
+
+            notify(
+
+                author,
+
+                f"По вашему документу запущено согласование ({cfg.label})",
+
+                text=f"«{doc_label}» — маршрут «{route}».",
+
+                url=_cabinet_url(),
+
+                kind=Notification.KIND_INFO,
+
+            )
+
+        return process
+
+
+
+    @staticmethod
+
+    def _create_review_task(process, step, *, is_recheck=False, parent=None):
+
+        assignee = resolve_assignee(step.department)
+
+        process.current_order = step.order
+
+        process.save(update_fields=["current_order"])
+
+
+
+        document = get_document_from_process(process)
+
+        cfg = get_config_for_document(document)
+
+        doc_label = _document_label(document)
+
+
+
+        task = ApprovalTask.objects.create(
+
+            process=process,
+
+            step=step,
+
+            department=step.department,
+
+            kind=ApprovalTask.KIND_REVIEW,
+
+            assigned_to=assignee,
+
+            is_recheck=is_recheck,
+
+            parent=parent,
+
+        )
+
+        is_sign = step.action_type == step.ACTION_SIGN
+
+        prefix = "Повторно: " if is_recheck else ""
+
+        action = "на согласование / подпись" if is_sign else "на ознакомление"
+
+        notify(
+
+            assignee,
+
+            f"{prefix}{cfg.label} {action}",
+
+            text=f"«{doc_label}» — отдел «{step.department}».",
+
+            url=_cabinet_url(),
+
+            kind=Notification.KIND_SIGN if is_sign else Notification.KIND_ACK,
+
+        )
+
+        return task
+
+
+
+    @staticmethod
+
+    @transaction.atomic
+
+    def approve(task, user, cert_info=None):
+
+        ApprovalEngine._guard_pending_review(task)
+
+
+
+        if task.step and task.step.action_type == task.step.ACTION_SIGN:
+
+            ApprovalEngine._record_signature(task, user, cert_info=cert_info)
+
+        elif task.step and task.step.action_type == task.step.ACTION_ACK:
+
+            ApprovalEngine._record_acknowledgment(task, user, cert_info=cert_info)
+
+
+
+        task.status = ApprovalTask.STATUS_APPROVED
+
+        task.resolved_at = timezone.now()
+
+        task.save(update_fields=["status", "resolved_at"])
+
+
+
+        process = task.process
+
+        document = get_document_from_process(process)
+
+        cfg = get_config_for_document(document)
+
+        doc_label = _document_label(document)
+
+
+
+        next_step = (
+
+            process.route.steps
+
+            .filter(order__gt=task.step.order)
+
+            .order_by("order")
+
+            .first()
+
+        )
+
+        if next_step:
+
+            ApprovalEngine._create_review_task(process, next_step)
+
+        else:
+
+            process.status = ApprovalProcess.STATUS_APPROVED
+
+            process.finished_at = timezone.now()
+
+            process.save(update_fields=["status", "finished_at"])
+
+            recipient = cfg.get_author(document) or process.started_by
+
+            notify(
+
+                recipient,
+
+                f"{cfg.label}: документ полностью согласован",
+
+                text=f"«{doc_label}» прошёл все шаги маршрута.",
+
+                url=_cabinet_url(),
+
+                kind=Notification.KIND_INFO,
+
+            )
+
+        return process
+
+
+
+    @staticmethod
+
+    @transaction.atomic
+
+    def reject(task, user, comment):
+
+        ApprovalEngine._guard_pending_review(task)
+
+        comment = (comment or "").strip()
+
+        if not comment:
+
+            raise ValueError("Укажите замечание для автора.")
+
+
+
+        document = get_document_from_process(task.process)
+
+        cfg = get_config_for_document(document)
+
+        doc_label = _document_label(document)
+
+
+
+        task.status = ApprovalTask.STATUS_REJECTED
+
+        task.comment = comment
+
+        task.resolved_at = timezone.now()
+
+        task.save(update_fields=["status", "comment", "resolved_at"])
+
+
+
+        author = cfg.get_author(document) or task.process.started_by
+
+        if author is None:
+
+            raise ValueError(
+
+                "У документа не указан автор — некому отправить на доработку."
+
+            )
+
+
+
+        ApprovalTask.objects.create(
+
+            process=task.process,
+
+            step=task.step,
+
+            department=task.department,
+
+            kind=ApprovalTask.KIND_FIX,
+
+            assigned_to=author,
+
+            comment=comment,
+
+            parent=task,
+
+        )
+
+        notify(
+
+            author,
+
+            f"{cfg.label}: документ вернули на доработку",
+
+            text=f"«{doc_label}» — отдел «{task.department}». Замечание: {comment}",
+
+            url=_cabinet_url(),
+
+            kind=Notification.KIND_FIX,
+
+        )
+
+        return task
+
+
+
+    @staticmethod
+
+    @transaction.atomic
+
+    def resubmit(fix_task, user):
+
+        if fix_task.kind != ApprovalTask.KIND_FIX:
+
+            raise ValueError("Это не задача на доработку.")
+
+        if fix_task.status != ApprovalTask.STATUS_PENDING:
+
+            raise ValueError("Эта задача на доработку уже закрыта.")
+
+
+
+        fix_task.status = ApprovalTask.STATUS_DONE
+
+        fix_task.resolved_at = timezone.now()
+
+        fix_task.save(update_fields=["status", "resolved_at"])
+
+
+
+        ApprovalEngine._create_review_task(
+
+            fix_task.process, fix_task.step, is_recheck=True, parent=fix_task
+
+        )
+
+        return fix_task
+
+
+
+    @staticmethod
+
+    @transaction.atomic
+
+    def cancel(process, user):
+
+        if process.status != ApprovalProcess.STATUS_IN_PROGRESS:
+
+            raise ValueError("Согласование уже завершено или отменено.")
+
+        process.tasks.filter(status=ApprovalTask.STATUS_PENDING).update(
+
+            status=ApprovalTask.STATUS_CANCELLED,
+
+            resolved_at=timezone.now(),
+
+        )
+
+        process.status = ApprovalProcess.STATUS_CANCELLED
+
+        process.finished_at = timezone.now()
+
+        process.save(update_fields=["status", "finished_at"])
+
+
+
+        document = get_document_from_process(process)
+
+        cfg = get_config_for_document(document)
+
+        doc_label = _document_label(document)
+
+        recipient = cfg.get_author(document) or process.started_by
+
+        if recipient:
+
+            notify(
+
+                recipient,
+
+                f"{cfg.label}: согласование отменено",
+
+                text=f"«{doc_label}» — маршрут «{process.route}».",
+
+                url=_cabinet_url(),
+
+                kind=Notification.KIND_INFO,
+
+            )
+
+        return process
+
+
+
+    @staticmethod
+
+    def _record_signature(task, user, cert_info=None):
+
+        document = get_document_from_process(task.process)
+
+        cfg = get_config_for_document(document)
+
+        cert_cn = cert_info.get("cn", "") if cert_info else ""
+
+        cert_issuer = cert_info.get("issuer_cn", "") if cert_info else ""
+
+        role_label = role_label_for_department(task.department)
+
+        position = str(task.department) if task.department else role_label
+
+
+
+        if cfg.key == "rkd":
+
+            from blog.models import UniversalRKDSignature
+
+
+
+            role = (task.department and task.department.signature_role) or "agreed"
+
+            UniversalRKDSignature.objects.update_or_create(
+
+                rkd=document,
+
+                role=role,
+
+                defaults={
+
+                    "signed_by": user,
+
+                    "signed_at": timezone.localdate(),
+
+                    "cert_cn": cert_cn,
+
+                    "cert_issuer": cert_issuer,
+
+                },
+
+            )
+
+        else:
+
+            ct = ContentType.objects.get_for_model(document)
+
+            ApprovalSheetRecord.objects.update_or_create(
+
+                task=task,
+
+                defaults={
+
+                    "process": task.process,
+
+                    "sheet_type": ApprovalSheetRecord.SHEET_APPROVAL,
+
+                    "content_type": ct,
+
+                    "object_id": document.pk,
+
+                    "department": task.department,
+
+                    "position": role_label,
+
+                    "role_label": role_label,
+
+                    "signed_by": user,
+
+                    "signed_at": timezone.localdate(),
+
+                    "cert_cn": cert_cn,
+
+                    "cert_issuer": cert_issuer,
+
+                    "step_order": task.step.order if task.step else 0,
+
+                },
+
+            )
+
+
+
+        try:
+
+            from .sheet_service import generate_approval_sheet
+
+            generate_approval_sheet(document, task.process)
+
+        except Exception:
+
+            pass
+
+
+
+    @staticmethod
+
+    def _record_acknowledgment(task, user, cert_info=None):
+
+        document = get_document_from_process(task.process)
+
+        cfg = get_config_for_document(document)
+
+        process = task.process
+
+        cert_cn = cert_info.get("cn", "") if cert_info else ""
+
+        cert_issuer = cert_info.get("issuer_cn", "") if cert_info else ""
+
+        position = str(task.department) if task.department else ""
+
+
+
+        if cfg.key == "rkd":
+
+            from blog.models import UniversalRKDAcknowledgment
+
+
+
+            UniversalRKDAcknowledgment.objects.update_or_create(
+
+                task=task,
+
+                defaults={
+
+                    "rkd": document,
+
+                    "process": process,
+
+                    "department": task.department,
+
+                    "position": position,
+
+                    "signed_by": user,
+
+                    "signed_at": timezone.localdate(),
+
+                    "cert_cn": cert_cn,
+
+                    "cert_issuer": cert_issuer,
+
+                    "step_order": task.step.order if task.step else 0,
+
+                },
+
+            )
+
+        else:
+
+            ct = ContentType.objects.get_for_model(document)
+
+            ApprovalSheetRecord.objects.update_or_create(
+
+                task=task,
+
+                defaults={
+
+                    "process": process,
+
+                    "sheet_type": ApprovalSheetRecord.SHEET_ACQUAINTANCE,
+
+                    "content_type": ct,
+
+                    "object_id": document.pk,
+
+                    "department": task.department,
+
+                    "position": position,
+
+                    "role_label": "",
+
+                    "signed_by": user,
+
+                    "signed_at": timezone.localdate(),
+
+                    "cert_cn": cert_cn,
+
+                    "cert_issuer": cert_issuer,
+
+                    "step_order": task.step.order if task.step else 0,
+
+                },
+
+            )
+
+
+
+        try:
+
+            from .sheet_service import generate_acquaintance_sheet
+
+            generate_acquaintance_sheet(document, process)
+
+        except Exception:
+
+            pass
+
+
+
+    @staticmethod
+
+    def _guard_pending_review(task):
+
+        if task.kind != ApprovalTask.KIND_REVIEW:
+
+            raise ValueError("Действие доступно только для задач проверки.")
+
+        if task.status != ApprovalTask.STATUS_PENDING:
+
+            raise ValueError("Эта задача уже обработана.")
+
+

--- a/approvals/sheet_service.py
+++ b/approvals/sheet_service.py
@@ -1,0 +1,162 @@
+import os
+import re
+from datetime import datetime
+
+from django.core.files.base import ContentFile
+from django.template.loader import render_to_string
+from django.utils import timezone
+from weasyprint import HTML
+
+from .document_types import get_config_for_document
+from .models import ApprovalSheetRecord
+
+
+def _safe_part(value: str, fallback: str = "doc") -> str:
+    cleaned = re.sub(r'[\\/:*?"<>|]', "_", (value or "").strip())
+    return cleaned or fallback
+
+
+def _build_rows(records) -> list[dict]:
+    rows = []
+    for i, rec in enumerate(records, start=1):
+        fio = rec.cert_cn or (
+            rec.signed_by.get_full_name() or rec.signed_by.username
+            if rec.signed_by else "—"
+        )
+        date_str = rec.signed_at.strftime("%d.%m.%Y") if rec.signed_at else ""
+        position = rec.role_label or rec.position or "—"
+        rows.append({
+            "number": i,
+            "position": position,
+            "fio": fio,
+            "cert_cn": rec.cert_cn or "",
+            "cert_issuer": rec.cert_issuer or "",
+            "date": date_str,
+        })
+    return rows
+
+
+def _collect_rkd_approval_rows(rkd) -> list[dict]:
+    rows = []
+    for i, sig in enumerate(
+        rkd.signatures.select_related("signed_by").order_by("role"), start=1
+    ):
+        date_str = ""
+        if getattr(sig, "signed_at", None):
+            date_str = sig.signed_at.strftime("%d.%m.%Y")
+        elif sig.signature_file:
+            try:
+                mtime = os.path.getmtime(sig.signature_file.path)
+                date_str = datetime.fromtimestamp(mtime).strftime("%d.%m.%Y")
+            except Exception:
+                pass
+        cert_cn = getattr(sig, "cert_cn", "") or ""
+        fio = cert_cn or (
+            sig.signed_by.get_full_name() or sig.signed_by.username
+            if sig.signed_by else "—"
+        )
+        rows.append({
+            "number": i,
+            "position": sig.get_role_display(),
+            "fio": fio,
+            "cert_cn": cert_cn,
+            "cert_issuer": getattr(sig, "cert_issuer", "") or "",
+            "date": date_str,
+        })
+    return rows
+
+
+def _collect_rkd_acquaintance_rows(rkd, process) -> list[dict]:
+    from blog.models import UniversalRKDAcknowledgment
+
+    acks = (
+        UniversalRKDAcknowledgment.objects
+        .filter(rkd=rkd, process=process)
+        .select_related("signed_by", "department")
+        .order_by("step_order", "pk")
+    )
+    rows = []
+    for i, ack in enumerate(acks, start=1):
+        fio = ack.cert_cn or (
+            ack.signed_by.get_full_name() or ack.signed_by.username
+            if ack.signed_by else "—"
+        )
+        date_str = ack.signed_at.strftime("%d.%m.%Y") if ack.signed_at else ""
+        rows.append({
+            "number": i,
+            "position": ack.position or (str(ack.department) if ack.department else "—"),
+            "fio": fio,
+            "cert_cn": ack.cert_cn or "",
+            "cert_issuer": ack.cert_issuer or "",
+            "date": date_str,
+        })
+    return rows
+
+
+def _collect_generic_rows(process, sheet_type) -> list[dict]:
+    records = (
+        ApprovalSheetRecord.objects
+        .filter(process=process, sheet_type=sheet_type)
+        .select_related("signed_by", "department")
+        .order_by("step_order", "pk")
+    )
+    return _build_rows(records)
+
+
+def _render_pdf(document, *, sheet_title: str, rows: list[dict]) -> bytes:
+    cfg = get_config_for_document(document)
+    context = {
+        "sheet_title": sheet_title,
+        "center_line": cfg.get_center_line(document),
+        "doc_info_lines": cfg.get_doc_info_lines(document),
+        "rows": rows,
+        "generated_at": timezone.now(),
+    }
+    html_string = render_to_string("pdf/workflow_sheet_template.html", context)
+    return HTML(string=html_string).write_pdf()
+
+
+def _save_pdf(document, field_name: str, prefix: str, name_part: str, pdf_bytes: bytes):
+    cfg = get_config_for_document(document)
+    filename = f"{prefix}_{_safe_part(name_part, str(document.pk))}.pdf"
+    existing = getattr(document, field_name, None)
+    if existing:
+        existing.delete(save=False)
+    getattr(document, field_name).save(filename, ContentFile(pdf_bytes), save=True)
+    return filename
+
+
+def generate_approval_sheet(document, process=None):
+    cfg = get_config_for_document(document)
+    if cfg.key == "rkd":
+        rows = _collect_rkd_approval_rows(document)
+    else:
+        rows = _collect_generic_rows(process, ApprovalSheetRecord.SHEET_APPROVAL)
+
+    pdf_bytes = _render_pdf(document, sheet_title="Лист утверждения", rows=rows)
+    name_part = cfg.get_center_line(document)
+    return _save_pdf(
+        document,
+        cfg.approval_document_field,
+        cfg.approval_filename_prefix,
+        name_part,
+        pdf_bytes,
+    )
+
+
+def generate_acquaintance_sheet(document, process):
+    cfg = get_config_for_document(document)
+    if cfg.key == "rkd":
+        rows = _collect_rkd_acquaintance_rows(document, process)
+    else:
+        rows = _collect_generic_rows(process, ApprovalSheetRecord.SHEET_ACQUAINTANCE)
+
+    pdf_bytes = _render_pdf(document, sheet_title="Лист ознакомления", rows=rows)
+    name_part = cfg.get_center_line(document)
+    return _save_pdf(
+        document,
+        cfg.acquaintance_document_field,
+        cfg.acquaintance_filename_prefix,
+        name_part,
+        pdf_bytes,
+    )

--- a/approvals/sign_utils.py
+++ b/approvals/sign_utils.py
@@ -1,0 +1,425 @@
+import base64
+
+import hashlib
+
+import mimetypes
+
+import re
+
+
+
+from django.core.files.base import ContentFile
+
+from django.utils import timezone
+
+
+
+from .document_types import get_config_for_document, get_document_from_process
+
+
+
+try:
+
+    from asn1crypto import cms, pem as asn1_pem
+
+
+
+    _HAS_ASN1CRYPTO = True
+
+except ImportError:
+
+    _HAS_ASN1CRYPTO = False
+
+
+
+
+
+class SignDocumentError(ValueError):
+
+    pass
+
+
+
+
+
+def get_main_document(process):
+
+    document = get_document_from_process(process)
+
+    if document is None:
+
+        raise SignDocumentError("Документ согласования не найден.")
+
+    cfg = get_config_for_document(document)
+
+    doc = cfg.get_main_file(document)
+
+    if not doc or not doc.name:
+
+        raise SignDocumentError(cfg.no_file_message.replace(
+
+            "перед отправкой на согласование", "перед подписанием"
+
+        ))
+
+    return document, cfg, doc
+
+
+
+
+
+def get_rkd_main_document(rkd):
+
+    from .document_types import DOCUMENT_TYPES
+
+    cfg = DOCUMENT_TYPES["rkd"]
+
+    doc = cfg.get_main_file(rkd)
+
+    if not doc or not doc.name:
+
+        raise SignDocumentError(cfg.no_file_message.replace(
+
+            "перед отправкой на согласование", "перед подписанием"
+
+        ))
+
+    return doc
+
+
+
+
+
+def read_sign_document_bytes(task) -> bytes:
+
+    _, _, doc = get_main_document(task.process)
+
+    with doc.open("rb") as fp:
+
+        return fp.read()
+
+
+
+
+
+def build_sign_payload_meta(task) -> str:
+
+    _, _, doc = get_main_document(task.process)
+
+    data = read_sign_document_bytes(task)
+
+    filename = doc.name.rsplit("/", 1)[-1]
+
+    digest = hashlib.sha256(data).hexdigest()
+
+    return f"file:{filename}\nsha256:{digest}\nsize:{len(data)}"
+
+
+
+
+
+def parse_signed_payload_meta(payload: str) -> dict:
+
+    meta = {}
+
+    for line in (payload or "").strip().splitlines():
+
+        if ":" in line:
+
+            key, value = line.split(":", 1)
+
+            meta[key.strip()] = value.strip()
+
+    return meta
+
+
+
+
+
+def is_file_payload(payload: str) -> bool:
+
+    return (payload or "").startswith("file:")
+
+
+
+
+
+def get_signed_document_for_download(task):
+
+    _, _, doc = get_main_document(task.process)
+
+    data = read_sign_document_bytes(task)
+
+    meta = parse_signed_payload_meta(task.signed_payload or "")
+
+    expected = meta.get("sha256")
+
+    if expected and hashlib.sha256(data).hexdigest() != expected:
+
+        raise SignDocumentError("Документ изменён после подписания.")
+
+    filename = meta.get("file") or doc.name.rsplit("/", 1)[-1]
+
+    content_type, _ = mimetypes.guess_type(filename)
+
+    return data, filename, content_type or "application/octet-stream"
+
+
+
+
+
+def _safe_filename_part(value: str, fallback: str = "doc") -> str:
+
+    cleaned = re.sub(r'[\\/:*?"<>|]', "_", (value or "").strip())
+
+    return cleaned or fallback
+
+
+
+
+
+def save_task_signature(task, sig_b64: str, *, cert_info: dict | None = None) -> None:
+
+    payload_meta = build_sign_payload_meta(task)
+
+    task.signed_payload = payload_meta
+
+    task.signature_b64 = sig_b64
+
+
+
+    update_fields = ["signature_b64", "signature_file", "signed_payload"]
+
+    if cert_info:
+
+        task.signer_cn = cert_info.get("cn", "")
+
+        task.signer_cert_serial = cert_info.get("serial_hex", "")
+
+        task.signer_cert_valid_to = cert_info.get("valid_to", "")
+
+        task.signer_cert_issuer = cert_info.get("issuer_cn", "")
+
+        update_fields.extend([
+
+            "signer_cn", "signer_cert_serial",
+
+            "signer_cert_valid_to", "signer_cert_issuer",
+
+        ])
+
+
+
+    raw = base64.b64decode(sig_b64)
+
+    document, cfg, _ = get_main_document(task.process)
+
+    name_part = _safe_filename_part(cfg.get_center_line(document), str(document.pk))
+
+    dept = _safe_filename_part(str(task.department) if task.department else "sign", "sign")
+
+    filename = f"ЛУ_{name_part}_{dept}_task{task.pk}.sig"
+
+
+
+    if task.signature_file:
+
+        task.signature_file.delete(save=False)
+
+    task.signature_file.save(filename, ContentFile(raw), save=False)
+
+    task.save(update_fields=update_fields)
+
+
+
+
+
+def parse_cms_signature(sig_b64: str) -> dict:
+
+    if not _HAS_ASN1CRYPTO:
+
+        raise ImportError(
+
+            "Для разбора подписи требуется пакет asn1crypto. "
+
+            "Установите: pip install asn1crypto"
+
+        )
+
+
+
+    try:
+
+        raw = base64.b64decode(sig_b64)
+
+    except Exception:
+
+        raise ValueError("Неверная кодировка данных (ожидается base64).")
+
+
+
+    if asn1_pem.detect(raw):
+
+        _, _, raw = asn1_pem.unarmor(raw)
+
+
+
+    try:
+
+        content_info = cms.ContentInfo.load(raw)
+
+    except Exception as exc:
+
+        raise ValueError(f"Не удалось разобрать CMS-структуру подписи: {exc}")
+
+
+
+    if content_info["content_type"].native != "signed_data":
+
+        raise ValueError("Неверный формат: ожидается SignedData (CMS/CAdES).")
+
+
+
+    signed_data = content_info["content"]
+
+    cert = _extract_signer_certificate(signed_data)
+
+    if cert is None:
+
+        raise ValueError("Не удалось определить сертификат подписанта в подписи.")
+
+
+
+    def _rdn(name_obj, *oid_names):
+
+        for rdn in name_obj.chosen:
+
+            for attr in rdn:
+
+                if attr["type"].native in oid_names:
+
+                    v = attr["value"]
+
+                    return v.native if hasattr(v, "native") else str(v)
+
+        return None
+
+
+
+    cn = _rdn(cert.subject, "common_name") or "Неизвестно"
+
+    issuer_cn = _rdn(cert.issuer, "common_name", "organization_name") or "—"
+
+
+
+    valid_to_dt = cert["tbs_certificate"]["validity"]["not_after"].native
+
+    try:
+
+        valid_to_str = valid_to_dt.strftime("%d.%m.%Y")
+
+    except Exception:
+
+        valid_to_str = str(valid_to_dt)
+
+
+
+    serial = cert.serial_number
+
+    serial_hex = format(serial, "X") if isinstance(serial, int) else str(serial)
+
+
+
+    return {
+
+        "cn": cn,
+
+        "issuer_cn": issuer_cn,
+
+        "valid_to": valid_to_str,
+
+        "serial_hex": serial_hex,
+
+    }
+
+
+
+
+
+def _extract_signer_certificate(signed_data):
+
+    signer_infos = signed_data["signer_infos"]
+
+    if not signer_infos:
+
+        return None
+
+
+
+    sid = signer_infos[0]["sid"].chosen
+
+    certs = signed_data["certificates"] or []
+
+
+
+    for cert_holder in certs:
+
+        candidate = cert_holder.chosen
+
+        if _certificate_matches_signer_id(candidate, sid):
+
+            return candidate
+
+
+
+    for cert_holder in certs:
+
+        candidate = cert_holder.chosen
+
+        if not _looks_like_ca_certificate(candidate):
+
+            return candidate
+
+
+
+    return certs[0].chosen if certs else None
+
+
+
+
+
+def _certificate_matches_signer_id(cert, sid):
+
+    sid_type = sid.__class__.__name__.lower()
+
+    if "issuerandserialnumber" in sid_type:
+
+        return cert.issuer.dump() == sid["issuer"].dump() and cert.serial_number == sid["serial_number"].native
+
+    if "subjectkeyidentifier" in sid_type:
+
+        ski_ext = cert.subject_key_identifier
+
+        return ski_ext is not None and ski_ext.native == sid.native
+
+    return False
+
+
+
+
+
+def _looks_like_ca_certificate(cert):
+
+    bc = cert.basic_constraints_value
+
+    if bc is not None and bc["ca"].native:
+
+        return True
+
+    issuer_dn = cert.issuer.human_friendly
+
+    subject_dn = cert.subject.human_friendly
+
+    return issuer_dn == subject_dn
+
+

--- a/approvals/static/approvals/js/cadesplugin_api.js
+++ b/approvals/static/approvals/js/cadesplugin_api.js
@@ -1,0 +1,942 @@
+; (function () {
+    //already loaded
+    if (window.cadesplugin && window.cadesplugin.LOG_LEVEL_DEBUG) {
+        return;
+    }
+    var pluginObject;
+    var plugin_resolved = 0;
+    var plugin_reject;
+    var plugin_resolve;
+    var isOpera = 0;
+    var isFireFox = 0;
+    var isSafari = 0;
+    var isYandex = 0;
+    var canPromise = !!window.Promise;
+    var cadesplugin_loaded_event_recieved = false;
+    var isFireFoxExtensionLoaded = false;
+    var cadesplugin = {};
+    var untrusted_sites_message_shown = false;
+
+    if (canPromise) {
+        cadesplugin = new window.Promise(function (resolve, reject) {
+            plugin_resolve = resolve;
+            plugin_reject = reject;
+        });
+    }
+
+    function check_browser() {
+        var ua = window.navigator.userAgent,
+            tem,
+            M = ua.match(/(opera|yabrowser|chrome|safari|firefox|msie|trident(?=\/))\/?\s*(\d+)/i) || [];
+        if (/trident/i.test(M[1])) {
+            tem = /\brv[ :]+(\d+)/g.exec(ua) || [];
+            return { name: 'IE', version: (tem[1] || '') };
+        }
+        if (M[1] === "Chrome") {
+            tem = ua.match(/\b(OPR|Edg|YaBrowser)\/(\d+)/);
+            if (tem != null && (tem.length > 2)) {
+                return { name: tem[1].replace('OPR', 'Opera'), version: tem[2] };
+            }
+        }
+        M = M[2] ? [M[1], M[2]] : [window.navigator.appName, window.navigator.appVersion, '-?'];
+        if ((tem = ua.match(/version\/(\d+)/i)) != null) {
+            M.splice(1, 1, tem[1]);
+        }
+        return { name: M[0], version: M[1] };
+    }
+
+    var browserSpecs = check_browser();
+
+    function cpcsp_console_log(level, msg) {
+        //IE9 не может писать в консоль если не открыта вкладка developer tools
+        if (typeof console === 'undefined') {
+            return;
+        }
+        if (level <= cadesplugin.current_log_level) {
+            if (level === cadesplugin.LOG_LEVEL_DEBUG) {
+                console.log("DEBUG: %s", msg);
+            }
+            if (level === cadesplugin.LOG_LEVEL_INFO) {
+                console.info("INFO: %s", msg);
+            }
+            if (level === cadesplugin.LOG_LEVEL_ERROR) {
+                console.error("ERROR: %s", msg);
+            }
+        }
+    }
+
+    function get_extension_version(callback) {
+        window.postMessage("cadesplugin_extension_version_request", "*");
+        window.addEventListener("message", function (event) {
+            var resp_prefix = "cadesplugin_extension_version_response:";
+            if (typeof (event.data) !== "string" || event.data.indexOf(resp_prefix) !== 0) {
+                return;
+            }
+            var ext_version = event.data.substring(resp_prefix.length);
+            callback(ext_version);
+        }, false);
+    }
+
+    function get_extension_id(callback) {
+        window.postMessage("cadesplugin_extension_id_request", "*");
+        window.addEventListener("message", function (event) {
+            var resp_prefix = "cadesplugin_extension_id_response:";
+            if (typeof (event.data) !== "string" || event.data.indexOf(resp_prefix) !== 0) {
+                return;
+            }
+            var ext_id = event.data.substring(resp_prefix.length);
+            callback(ext_id);
+        }, false);
+    }
+
+    function set_log_level(level) {
+        if (!((level === cadesplugin.LOG_LEVEL_DEBUG) ||
+            (level === cadesplugin.LOG_LEVEL_INFO) ||
+            (level === cadesplugin.LOG_LEVEL_ERROR))) {
+            cpcsp_console_log(cadesplugin.LOG_LEVEL_ERROR, "cadesplugin_api.js: Incorrect log_level: " + level);
+            return;
+        }
+        cadesplugin.current_log_level = level;
+        if (cadesplugin.current_log_level === cadesplugin.LOG_LEVEL_DEBUG) {
+            cpcsp_console_log(cadesplugin.LOG_LEVEL_INFO, "cadesplugin_api.js: log_level = DEBUG");
+        }
+        if (cadesplugin.current_log_level === cadesplugin.LOG_LEVEL_INFO) {
+            cpcsp_console_log(cadesplugin.LOG_LEVEL_INFO, "cadesplugin_api.js: log_level = INFO");
+        }
+        if (cadesplugin.current_log_level === cadesplugin.LOG_LEVEL_ERROR) {
+            cpcsp_console_log(cadesplugin.LOG_LEVEL_INFO, "cadesplugin_api.js: log_level = ERROR");
+        }
+        if (isNativeMessageSupported()) {
+            if (cadesplugin.current_log_level === cadesplugin.LOG_LEVEL_DEBUG) {
+                window.postMessage("set_log_level=debug", "*");
+            }
+            if (cadesplugin.current_log_level === cadesplugin.LOG_LEVEL_INFO) {
+                window.postMessage("set_log_level=info", "*");
+            }
+            if (cadesplugin.current_log_level === cadesplugin.LOG_LEVEL_ERROR) {
+                window.postMessage("set_log_level=error", "*");
+            }
+        }
+    }
+
+    function set_constantValues() {
+        cadesplugin.CAPICOM_MEMORY_STORE = 0;
+        cadesplugin.CAPICOM_LOCAL_MACHINE_STORE = 1;
+        cadesplugin.CAPICOM_CURRENT_USER_STORE = 2;
+        cadesplugin.CAPICOM_SMART_CARD_USER_STORE = 4;
+        cadesplugin.CADESCOM_MEMORY_STORE = 0;
+        cadesplugin.CADESCOM_LOCAL_MACHINE_STORE = 1;
+        cadesplugin.CADESCOM_CURRENT_USER_STORE = 2;
+        cadesplugin.CADESCOM_SMART_CARD_USER_STORE = 4;
+        cadesplugin.CADESCOM_CONTAINER_STORE = 100;
+
+        cadesplugin.CAPICOM_ROOT_STORE = "Root";
+        cadesplugin.CAPICOM_CA_STORE = "CA";
+        cadesplugin.CAPICOM_MY_STORE = "My";
+        cadesplugin.CAPICOM_ADDRESSBOOK_STORE = "AddressBook";
+
+        cadesplugin.CAPICOM_STORE_OPEN_READ_WRITE = 1;
+        cadesplugin.CAPICOM_STORE_OPEN_MAXIMUM_ALLOWED = 2;
+        cadesplugin.CAPICOM_STORE_OPEN_INCLUDE_ARCHIVED = 256;
+
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_SUBJECT_NAME = 1;
+
+        cadesplugin.CADESCOM_XML_SIGNATURE_TYPE_ENVELOPED = 0;
+        cadesplugin.CADESCOM_XML_SIGNATURE_TYPE_ENVELOPING = 1;
+        cadesplugin.CADESCOM_XML_SIGNATURE_TYPE_TEMPLATE = 2;
+
+        cadesplugin.CADESCOM_XADES_DEFAULT = 0x00000010;
+        cadesplugin.CADESCOM_XADES_BES = 0x00000020;
+        cadesplugin.CADESCOM_XADES_T = 0x00000050;
+        cadesplugin.CADESCOM_XADES_X_LONG_TYPE_1 = 0x000005d0;
+        cadesplugin.CADESCOM_XMLDSIG_TYPE = 0x00000000;
+
+        cadesplugin.XmlDsigGost3410UrlObsolete = "http://www.w3.org/2001/04/xmldsig-more#gostr34102001-gostr3411";
+        cadesplugin.XmlDsigGost3411UrlObsolete = "http://www.w3.org/2001/04/xmldsig-more#gostr3411";
+        cadesplugin.XmlDsigGost3410Url = "urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr34102001-gostr3411";
+        cadesplugin.XmlDsigGost3411Url = "urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr3411";
+
+        cadesplugin.XmlDsigGost3411Url2012256 = "urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr34112012-256";
+        cadesplugin.XmlDsigGost3410Url2012256 = "urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr34102012-gostr34112012-256";
+        cadesplugin.XmlDsigGost3411Url2012512 = "urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr34112012-512";
+        cadesplugin.XmlDsigGost3410Url2012512 = "urn:ietf:params:xml:ns:cpxmlsec:algorithms:gostr34102012-gostr34112012-512";
+
+        cadesplugin.CADESCOM_CADES_DEFAULT = 0;
+        cadesplugin.CADESCOM_CADES_BES = 1;
+        cadesplugin.CADESCOM_CADES_T = 0x5;
+        cadesplugin.CADESCOM_CADES_X_LONG_TYPE_1 = 0x5d;
+        cadesplugin.CADESCOM_CADES_A = 0xdd;
+        cadesplugin.CADESCOM_PKCS7_TYPE = 0xffff;
+
+        cadesplugin.CADESCOM_ENCODE_BASE64 = 0;
+        cadesplugin.CADESCOM_ENCODE_BINARY = 1;
+        cadesplugin.CADESCOM_ENCODE_ANY = -1;
+
+        cadesplugin.CAPICOM_CERTIFICATE_INCLUDE_CHAIN_EXCEPT_ROOT = 0;
+        cadesplugin.CAPICOM_CERTIFICATE_INCLUDE_WHOLE_CHAIN = 1;
+        cadesplugin.CAPICOM_CERTIFICATE_INCLUDE_END_ENTITY_ONLY = 2;
+        cadesplugin.CAPICOM_CERTIFICATE_INCLUDE_NONE = 0x100;
+
+        cadesplugin.CAPICOM_CERT_INFO_SUBJECT_SIMPLE_NAME = 0;
+        cadesplugin.CAPICOM_CERT_INFO_ISSUER_SIMPLE_NAME = 1;
+
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_SHA1_HASH = 0;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_SUBJECT_NAME = 1;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_ISSUER_NAME = 2;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_ROOT_NAME = 3;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_TEMPLATE_NAME = 4;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_EXTENSION = 5;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_EXTENDED_PROPERTY = 6;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_APPLICATION_POLICY = 7;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_CERTIFICATE_POLICY = 8;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_TIME_VALID = 9;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_TIME_NOT_YET_VALID = 10;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_TIME_EXPIRED = 11;
+        cadesplugin.CAPICOM_CERTIFICATE_FIND_KEY_USAGE = 12;
+
+        cadesplugin.CAPICOM_DIGITAL_SIGNATURE_KEY_USAGE = 128;
+
+        cadesplugin.CAPICOM_PROPID_ENHKEY_USAGE = 9;
+
+        cadesplugin.CAPICOM_OID_OTHER = 0;
+        cadesplugin.CAPICOM_OID_KEY_USAGE_EXTENSION = 10;
+
+        cadesplugin.CAPICOM_EKU_CLIENT_AUTH = 2;
+        cadesplugin.CAPICOM_EKU_SMARTCARD_LOGON = 5;
+        cadesplugin.CAPICOM_EKU_OTHER = 0;
+
+        cadesplugin.CAPICOM_AUTHENTICATED_ATTRIBUTE_SIGNING_TIME = 0;
+        cadesplugin.CAPICOM_AUTHENTICATED_ATTRIBUTE_DOCUMENT_NAME = 1;
+        cadesplugin.CAPICOM_AUTHENTICATED_ATTRIBUTE_DOCUMENT_DESCRIPTION = 2;
+        cadesplugin.CADESCOM_AUTHENTICATED_ATTRIBUTE_SIGNING_TIME = 0;
+        cadesplugin.CADESCOM_AUTHENTICATED_ATTRIBUTE_DOCUMENT_NAME = 1;
+        cadesplugin.CADESCOM_AUTHENTICATED_ATTRIBUTE_DOCUMENT_DESCRIPTION = 2;
+        cadesplugin.CADESCOM_AUTHENTICATED_ATTRIBUTE_MACHINE_INFO = 0x100;
+        cadesplugin.CADESCOM_ATTRIBUTE_OTHER = -1;
+
+        cadesplugin.CADESCOM_STRING_TO_UCS2LE = 0;
+        cadesplugin.CADESCOM_BASE64_TO_BINARY = 1;
+
+        cadesplugin.CADESCOM_DISPLAY_DATA_NONE = 0;
+        cadesplugin.CADESCOM_DISPLAY_DATA_CONTENT = 1;
+        cadesplugin.CADESCOM_DISPLAY_DATA_ATTRIBUTE = 2;
+
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_RC2 = 0;
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_RC4 = 1;
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_DES = 2;
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_3DES = 3;
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_AES = 4;
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_GOST_28147_89 = 25;
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_GOST_MAGMA = 35;
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_GOST_MAGMA_OMAC = 36;
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_GOST_KUZNYECHIK = 45;
+        cadesplugin.CADESCOM_ENCRYPTION_ALGORITHM_GOST_KUZNYECHIK_OMAC = 46;
+
+        cadesplugin.CADESCOM_HASH_ALGORITHM_SHA1 = 0;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_MD2 = 1;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_MD4 = 2;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_MD5 = 3;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_SHA_256 = 4;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_SHA_384 = 5;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_SHA_512 = 6;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411 = 100;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256 = 101;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_512 = 102;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_HMAC = 110;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_256_HMAC = 111;
+        cadesplugin.CADESCOM_HASH_ALGORITHM_CP_GOST_3411_2012_512_HMAC = 112;
+
+        cadesplugin.CADESCOM_CERT_INFO_ROLE = 100;
+        cadesplugin.CADESCOM_ROLE_ROOT = "ROOT";
+        cadesplugin.CADESCOM_ROLE_CA = "CA";
+        cadesplugin.CADESCOM_ROLE_LEAF = "LEAF";
+
+        cadesplugin.LOG_LEVEL_DEBUG = 4;
+        cadesplugin.LOG_LEVEL_INFO = 2;
+        cadesplugin.LOG_LEVEL_ERROR = 1;
+
+        cadesplugin.CADESCOM_AllowNone = 0;
+        cadesplugin.CADESCOM_AllowNoOutstandingRequest = 0x1;
+        cadesplugin.CADESCOM_AllowUntrustedCertificate = 0x2;
+        cadesplugin.CADESCOM_AllowUntrustedRoot = 0x4;
+        cadesplugin.CADESCOM_SkipInstallToStore = 0x10000000;
+        cadesplugin.CADESCOM_InstallCertChainToContainer = 0x20000000;
+        cadesplugin.CADESCOM_UseContainerStore = 0x40000000;
+
+        cadesplugin.ContextNone = 0;
+        cadesplugin.ContextUser = 0x1;
+        cadesplugin.ContextMachine = 0x2;
+        cadesplugin.ContextAdministratorForceMachine = 0x3;
+
+        cadesplugin.ENABLE_CARRIER_TYPE_CSP = 0x01;
+        cadesplugin.ENABLE_CARRIER_TYPE_FKC_NO_SM = 0x02;
+        cadesplugin.ENABLE_CARRIER_TYPE_FKC_SM = 0x04;
+        cadesplugin.ENABLE_ANY_CARRIER_TYPE = 0x07;
+
+        cadesplugin.DISABLE_EVERY_CARRIER_OPERATION = 0x00;
+        cadesplugin.ENABLE_CARRIER_OPEN_ENUM = 0x01;
+        cadesplugin.ENABLE_CARRIER_CREATE = 0x02;
+        cadesplugin.ENABLE_ANY_OPERATION = 0x03;
+
+        cadesplugin.CADESCOM_PRODUCT_CSP = 0;
+        cadesplugin.CADESCOM_PRODUCT_OCSP = 1;
+        cadesplugin.CADESCOM_PRODUCT_TSP = 2;
+
+        cadesplugin.MEDIA_TYPE_DEFAULT = 0x00000000;
+        cadesplugin.MEDIA_TYPE_REGISTRY = 0x00000001;
+        cadesplugin.MEDIA_TYPE_HDIMAGE = 0x00000002;
+        cadesplugin.MEDIA_TYPE_CLOUD = 0x00000004;
+        cadesplugin.MEDIA_TYPE_SCARD = 0x00000008;
+
+        cadesplugin.XCN_CRYPT_STRING_BASE64HEADER = 0;
+        cadesplugin.XCN_CRYPT_STRING_BASE64 = 0x1;
+        cadesplugin.XCN_CRYPT_STRING_BINARY = 0x2;
+        cadesplugin.XCN_CRYPT_STRING_BASE64REQUESTHEADER = 0x3;
+        cadesplugin.XCN_CRYPT_STRING_HEX = 0x4;
+        cadesplugin.XCN_CRYPT_STRING_HEXASCII = 0x5;
+        cadesplugin.XCN_CRYPT_STRING_BASE64_ANY = 0x6;
+        cadesplugin.XCN_CRYPT_STRING_ANY = 0x7;
+        cadesplugin.XCN_CRYPT_STRING_HEX_ANY = 0x8;
+        cadesplugin.XCN_CRYPT_STRING_BASE64X509CRLHEADER = 0x9;
+        cadesplugin.XCN_CRYPT_STRING_HEXADDR = 0xa;
+        cadesplugin.XCN_CRYPT_STRING_HEXASCIIADDR = 0xb;
+        cadesplugin.XCN_CRYPT_STRING_HEXRAW = 0xc;
+        cadesplugin.XCN_CRYPT_STRING_BASE64URI = 0xd;
+        cadesplugin.XCN_CRYPT_STRING_ENCODEMASK = 0xff;
+        cadesplugin.XCN_CRYPT_STRING_CHAIN = 0x100;
+        cadesplugin.XCN_CRYPT_STRING_TEXT = 0x200;
+        cadesplugin.XCN_CRYPT_STRING_PERCENTESCAPE = 0x8000000;
+        cadesplugin.XCN_CRYPT_STRING_HASHDATA = 0x10000000;
+        cadesplugin.XCN_CRYPT_STRING_STRICT = 0x20000000;
+        cadesplugin.XCN_CRYPT_STRING_NOCRLF = 0x40000000;
+        cadesplugin.XCN_CRYPT_STRING_NOCR = 0x80000000;
+
+        cadesplugin.XCN_CERT_NAME_STR_NONE = 0;
+        cadesplugin.XCN_AT_NONE = 0;
+        cadesplugin.XCN_AT_KEYEXCHANGE = 1;
+        cadesplugin.XCN_AT_SIGNATURE = 2;
+
+        cadesplugin.AT_KEYEXCHANGE = 1;
+        cadesplugin.AT_SIGNATURE = 2;
+
+        cadesplugin.CARRIER_FLAG_REMOVABLE = 1;
+        cadesplugin.CARRIER_FLAG_UNIQUE = 2;
+        cadesplugin.CARRIER_FLAG_PROTECTED = 4;
+        cadesplugin.CARRIER_FLAG_FUNCTIONAL_CARRIER = 8;
+        cadesplugin.CARRIER_FLAG_SECURE_MESSAGING = 16;
+        cadesplugin.CARRIER_FLAG_ABLE_SET_KEY = 32;
+        cadesplugin.CARRIER_FLAG_ABLE_VISUALISE_SIGNATURE = 64;
+        cadesplugin.CARRIER_FLAG_VIRTUAL = 128;
+
+        cadesplugin.CRYPT_MODE_CBCSTRICT = 1;
+        cadesplugin.CRYPT_MODE_CNT = 3;
+        cadesplugin.CRYPT_MODE_CBCRFC4357 = 31;
+        cadesplugin.CRYPT_MODE_CTR = 32;
+        cadesplugin.CRYPT_MODE_MGM = 33;
+        cadesplugin.CRYPT_MODE_GCM = 34;
+        cadesplugin.CRYPT_MODE_OMAC_CTR = 35;
+        cadesplugin.CRYPT_MODE_WRAP = 36;
+        cadesplugin.CRYPT_MODE_WRAP_PAD = 37;
+
+        cadesplugin.PKCS5_PADDING = 1;
+        cadesplugin.RANDOM_PADDING = 2;
+        cadesplugin.ZERO_PADDING = 3;
+        cadesplugin.ISO10126_PADDING = 4;
+        cadesplugin.ANSI_X923_PADDING = 5;
+        cadesplugin.TLS_1_0_PADDING = 6;
+        cadesplugin.ISO_IEC_7816_4_PADDING = 7;
+
+        cadesplugin.CAPICOM_STORE_SAVE_AS_SERIALIZED = 0;
+        cadesplugin.CAPICOM_STORE_SAVE_AS_PKCS7 = 1;
+
+        cadesplugin.CADESCOM_IDSCANNER_IMAGE_TYPE_W = 0x00;
+        cadesplugin.CADESCOM_IDSCANNER_IMAGE_TYPE_IR = 0x01;
+        cadesplugin.CADESCOM_IDSCANNER_IMAGE_TYPE_UV = 0x02;
+
+        cadesplugin.CERT_TRUST_NO_ERROR = 0x00000000;
+        cadesplugin.CERT_TRUST_IS_NOT_TIME_VALID = 0x00000001;
+        cadesplugin.CERT_TRUST_IS_REVOKED = 0x00000004;
+        cadesplugin.CERT_TRUST_IS_NOT_SIGNATURE_VALID = 0x00000008;
+        cadesplugin.CERT_TRUST_IS_NOT_VALID_FOR_USAGE = 0x00000010;
+        cadesplugin.CERT_TRUST_IS_UNTRUSTED_ROOT = 0x00000020;
+        cadesplugin.CERT_TRUST_REVOCATION_STATUS_UNKNOWN = 0x00000040;
+        cadesplugin.CERT_TRUST_IS_CYCLIC = 0x00000080;
+        cadesplugin.CERT_TRUST_INVALID_EXTENSION = 0x00000100;
+        cadesplugin.CERT_TRUST_INVALID_POLICY_CONSTRAINTS = 0x00000200;
+        cadesplugin.CERT_TRUST_INVALID_BASIC_CONSTRAINTS = 0x00000400;
+        cadesplugin.CERT_TRUST_INVALID_NAME_CONSTRAINTS = 0x00000800;
+        cadesplugin.CERT_TRUST_HAS_NOT_SUPPORTED_NAME_CONSTRAINT = 0x00001000;
+        cadesplugin.CERT_TRUST_HAS_NOT_DEFINED_NAME_CONSTRAINT = 0x00002000;
+        cadesplugin.CERT_TRUST_HAS_NOT_PERMITTED_NAME_CONSTRAINT = 0x00004000;
+        cadesplugin.CERT_TRUST_HAS_EXCLUDED_NAME_CONSTRAINT = 0x00008000;
+        cadesplugin.CERT_TRUST_IS_OFFLINE_REVOCATION = 0x01000000;
+        cadesplugin.CERT_TRUST_NO_ISSUANCE_CHAIN_POLICY = 0x02000000;
+        cadesplugin.CERT_TRUST_IS_EXPLICIT_DISTRUST = 0x04000000;
+        cadesplugin.CERT_TRUST_HAS_NOT_SUPPORTED_CRITICAL_EXT = 0x08000000;
+        cadesplugin.CERT_TRUST_HAS_WEAK_SIGNATURE = 0x00100000;
+
+        cadesplugin.XCN_CERT_NO_KEY_USAGE = 0;
+        cadesplugin.XCN_CERT_DIGITAL_SIGNATURE_KEY_USAGE = 0x80;
+        cadesplugin.XCN_CERT_NON_REPUDIATION_KEY_USAGE = 0x40;
+        cadesplugin.XCN_CERT_KEY_ENCIPHERMENT_KEY_USAGE = 0x20;
+        cadesplugin.XCN_CERT_DATA_ENCIPHERMENT_KEY_USAGE = 0x10;
+        cadesplugin.XCN_CERT_KEY_AGREEMENT_KEY_USAGE = 0x8;
+        cadesplugin.XCN_CERT_KEY_CERT_SIGN_KEY_USAGE = 0x4;
+        cadesplugin.XCN_CERT_OFFLINE_CRL_SIGN_KEY_USAGE = 0x2;
+        cadesplugin.XCN_CERT_CRL_SIGN_KEY_USAGE = 0x2;
+        cadesplugin.XCN_CERT_ENCIPHER_ONLY_KEY_USAGE = 0x1;
+        cadesplugin.XCN_CERT_DECIPHER_ONLY_KEY_USAGE = 0x8000;
+
+        cadesplugin.CADESCOM_XADES_ACCEPT_ANY_ID_ATTR_NAMESPACE = 1;
+        cadesplugin.CADES_USE_OCSP_AUTHORIZED_POLICY = 0x00020000;
+
+        cadesplugin.XCN_NCRYPT_NO_OPERATION = 0;
+        cadesplugin.XCN_NCRYPT_CIPHER_OPERATION = 0x1;
+        cadesplugin.XCN_NCRYPT_HASH_OPERATION = 0x2;
+        cadesplugin.XCN_NCRYPT_ASYMMETRIC_ENCRYPTION_OPERATION = 0x4;
+        cadesplugin.XCN_NCRYPT_SECRET_AGREEMENT_OPERATION = 0x8;
+        cadesplugin.XCN_NCRYPT_SIGNATURE_OPERATION = 0x10;
+        cadesplugin.XCN_NCRYPT_RNG_OPERATION = 0x20;
+
+        cadesplugin.XCN_CRYPT_ANY_GROUP_ID = 0;
+        cadesplugin.XCN_CRYPT_HASH_ALG_OID_GROUP_ID = 1;
+        cadesplugin.XCN_CRYPT_ENCRYPT_ALG_OID_GROUP_ID = 2;
+        cadesplugin.XCN_CRYPT_PUBKEY_ALG_OID_GROUP_ID = 3;
+        cadesplugin.XCN_CRYPT_SIGN_ALG_OID_GROUP_ID = 4;
+        cadesplugin.XCN_CRYPT_RDN_ATTR_OID_GROUP_ID = 5;
+        cadesplugin.XCN_CRYPT_EXT_OR_ATTR_OID_GROUP_ID = 6;
+        cadesplugin.XCN_CRYPT_ENHKEY_USAGE_OID_GROUP_ID = 7;
+        cadesplugin.XCN_CRYPT_POLICY_OID_GROUP_ID = 8;
+        cadesplugin.XCN_CRYPT_TEMPLATE_OID_GROUP_ID = 9;
+
+        cadesplugin.XCN_CRYPT_OID_INFO_PUBKEY_ANY = 0;
+        cadesplugin.XCN_CRYPT_OID_INFO_PUBKEY_SIGN_KEY_FLAG = 0x80000000;
+        cadesplugin.XCN_CRYPT_OID_INFO_PUBKEY_ENCRYPT_KEY_FLAG = 0x40000000;
+
+        cadesplugin.CONTROL_KEY_TIME_VALIDITY_DISABLED = 0;
+        cadesplugin.CONTROL_KEY_TIME_VALIDITY_ENABLED = 1;
+        cadesplugin.CONTROL_KEY_TIME_VALIDITY_STRICT = 2;
+
+        cadesplugin.AlgorithmFlagsNone = 0;
+        cadesplugin.AlgorithmFlagsWrap = 0x1;
+    }
+
+    function async_spawn(generatorFunc) {
+        function continuer(verb, arg) {
+            var result;
+            try {
+                result = generator[verb](arg);
+            } catch (err) {
+                return window.Promise.reject(err);
+            }
+            if (result.done) {
+                return result.value;
+            } else {
+                return window.Promise.resolve(result.value).then(onFulfilled, onRejected);
+            }
+        }
+        var generator = generatorFunc(Array.prototype.slice.call(arguments, 1));
+        var onFulfilled = continuer.bind(continuer, "next");
+        var onRejected = continuer.bind(continuer, "throw");
+        return onFulfilled();
+    }
+
+    function isIE() {
+        // var retVal = (("Microsoft Internet Explorer" == navigator.appName) || // IE < 11
+        //     navigator.userAgent.match(/Trident\/./i)); // IE 11
+        return (browserSpecs.name === 'IE' || browserSpecs.name === 'MSIE');
+    }
+
+    function isIOS() {
+        return (window.navigator.userAgent.match(/ipod/i) ||
+            window.navigator.userAgent.match(/ipad/i) ||
+            window.navigator.userAgent.match(/iphone/i));
+    }
+
+    function isNativeMessageSupported() {
+        // В IE работаем через NPAPI
+        if (isIE()) {
+            return false;
+        }
+        // В Edge работаем через NativeMessage
+        if (browserSpecs.name === 'Edg') {
+            return true;
+        }
+        if (browserSpecs.name === 'YaBrowser') {
+            isYandex = true;
+            return true;
+        }
+        // В Chrome, Firefox, Safari и Opera работаем через асинхронную версию в зависимости от версии
+        if (browserSpecs.name === 'Opera') {
+            isOpera = true;
+            return (browserSpecs.version >= 33);
+        }
+        if (browserSpecs.name === 'Firefox') {
+            isFireFox = true;
+            return (browserSpecs.version >= 52);
+        }
+        if (browserSpecs.name === 'Chrome') {
+            return (browserSpecs.version >= 42);
+        }
+        //В Сафари начиная с 12 версии нет NPAPI
+        if (browserSpecs.name === 'Safari') {
+            isSafari = true;
+            return (browserSpecs.version >= 12);
+        }
+    }
+
+    function untrustedSitesHandle(msg) {
+        if (window.cadesplugin_untrusted_sites_disabled_callback) {
+            window.cadesplugin_untrusted_sites_disabled_callback(msg);
+        } else {
+            if (!untrusted_sites_message_shown) {
+                untrusted_sites_message_shown = true;
+                alert("Данный сайт отсутствует в Списке доверенных узлов. Работа плагина плагина на таких сайтах запрещена. Обратитесь к Администратору.");
+            }
+        }
+    }
+
+    // Функция активации объектов КриптоПро ЭЦП Browser plug-in
+    function CreateObject(name) {
+        if (isIOS()) {
+            // На iOS для создания объектов используется функция
+            // call_ru_cryptopro_npcades_10_native_bridge, определенная в IOS_npcades_supp.js
+            return call_ru_cryptopro_npcades_10_native_bridge("CreateObject", [name]);
+        }
+        var objWebClassFactory;
+        if (isIE()) {
+            // В Internet Explorer создаются COM-объекты
+            if (name.match(/X509Enrollment/i)) {
+                try {
+                    // Объекты CertEnroll пробуем создавать через нашу фабрику,
+                    // если не получилось то через CX509EnrollmentWebClassFactory
+                    objWebClassFactory = document.getElementById("webClassFactory");
+                    return objWebClassFactory.CreateObject(name);
+                }
+                catch (e) {
+                    var err = cadesplugin.getLastError(e);
+                    if (err.indexOf("0xC2110F00") !== -1) {
+                        var msg = "Данный сайт отсутствует в Списке доверенных узлов. (0xC2110F00)";
+                        untrustedSitesHandle(msg);
+                        throw (msg);
+                    }
+                    try {
+                        var objCertEnrollClassFactory = document.getElementById("certEnrollClassFactory");
+                        return objCertEnrollClassFactory.CreateObject(name);
+                    }
+                    catch (err) {
+                        throw ("Для создания обьектов X509Enrollment следует настроить веб-узел на использование проверки подлинности по протоколу HTTPS");
+                    }
+                }
+            }
+            // Объекты CAPICOM и CAdESCOM создаются через CAdESCOM.WebClassFactory
+            try {
+                objWebClassFactory = document.getElementById("webClassFactory");
+                return objWebClassFactory.CreateObject(name);
+            } catch (e) {
+                var err = cadesplugin.getLastError(e);
+                if (err.indexOf("0xC2110F00") !== -1) {
+                    var msg = "Данный сайт отсутствует в Списке доверенных узлов. (0xC2110F00)";
+                    untrustedSitesHandle(msg);
+                    throw (msg);
+                }
+                // Для версий плагина ниже 2.0.12538
+                return new window.ActiveXObject(name);
+            }
+        }
+        // создаются объекты NPAPI
+        return pluginObject.CreateObject(name);
+    }
+
+    function decimalToHexString(number) {
+        if (number < 0) {
+            number = 0xFFFFFFFF + number + 1;
+        }
+
+        return number.toString(16).toUpperCase();
+    }
+
+    function GetMessageFromException(e) {
+        var err = e.message;
+        if (!err) {
+            err = e;
+        } else if (e.number) {
+            err += " (0x" + decimalToHexString(e.number) + ")";
+        }
+        return err;
+    }
+
+    function getLastError(exception) {
+        if (isNativeMessageSupported() || isIE() || isIOS()) {
+            return GetMessageFromException(exception);
+        }
+
+        try {
+            return pluginObject.getLastError();
+        } catch (e) {
+            return GetMessageFromException(exception);
+        }
+    }
+
+    // Функция для удаления созданных объектов
+    function ReleasePluginObjects() {
+        // noinspection JSUnresolvedVariable
+        return cpcsp_chrome_nmcades.ReleasePluginObjects();
+    }
+
+    // Функция активации асинхронных объектов КриптоПро ЭЦП Browser plug-in
+    function CreateObjectAsync(name) {
+        return pluginObject.CreateObjectAsync(name);
+    }
+
+    // Функции для IOS
+    // noinspection JSUnusedGlobalSymbols
+    var ru_cryptopro_npcades_10_native_bridge = {
+        callbacksCount: 1,
+        callbacks: {},
+
+        // Automatically called by native layer when a result is available
+        resultForCallback: function resultForCallback(callbackId, resultArray) {
+            var callback = ru_cryptopro_npcades_10_native_bridge.callbacks[callbackId];
+            if (!callback) {
+                return;
+            }
+            callback.apply(null, resultArray);
+        },
+
+        // Use this in javascript to request native objective-c code
+        // functionName : string (I think the name is explicit :p)
+        // args : array of arguments
+        // callback : function with n-arguments that is going to be called when the native code returned
+        call: function call(functionName, args, callback) {
+            var hasCallback = callback && typeof callback === "function";
+            var callbackId = hasCallback ? ru_cryptopro_npcades_10_native_bridge.callbacksCount++ : 0;
+
+            if (hasCallback) {
+                ru_cryptopro_npcades_10_native_bridge.callbacks[callbackId] = callback;
+            }
+
+            var iframe = document.createElement("IFRAME");
+            var arrObjs = new Array("_CPNP_handle");
+            try {
+                iframe.setAttribute("src", "cpnp-js-call:" + functionName + ":" + callbackId + ":" + encodeURIComponent(window.JSON.stringify(args, arrObjs)));
+            } catch (e) {
+                window.alert(e);
+            }
+            document.documentElement.appendChild(iframe);
+            iframe.parentNode.removeChild(iframe);
+            iframe = null;
+        }
+    };
+
+    function call_ru_cryptopro_npcades_10_native_bridge(functionName, array) {
+        var tmpobj;
+        var ex;
+        ru_cryptopro_npcades_10_native_bridge.call(functionName, array, function (e, response) {
+            ex = e;
+            var tmpobj = "";
+            try {
+                tmpobj = window.JSON.parse(response);
+            }
+            catch (err) {
+                tmpobj = response;
+            }
+            if (typeof tmpobj === "string") {
+                tmpobj = tmpobj.replace(/\\\n/gm, "\n");
+                tmpobj = tmpobj.replace(/\\\r/gm, "\r");
+            }
+        });
+        if (ex) {
+            throw ex;
+        }
+        return tmpobj;
+    }
+
+    function show_firefox_missing_extension_dialog() {
+        if (!window.cadesplugin_skip_extension_install) {
+            var ovr = document.createElement('div');
+            ovr.id = "cadesplugin_ovr";
+            ovr.style = "visibility: hidden; position: fixed; left: 0; top: 0; width:100%; height:100%; background-color: rgba(0,0,0,0.7)";
+            ovr.innerHTML = "<div id='cadesplugin_ovr_item' style='position:relative; max-width:400px; margin:100px auto; background-color:#fff; border:2px solid #000; padding:10px; text-align:center; opacity: 1; z-index: 1500'>" +
+                "<button id='cadesplugin_close_install' style='float: right; font-size: 10px; background: transparent; border: 1; margin: -5px'>X</button>" +
+                "<p>Для работы КриптоПро ЭЦП Browser plugin на данном сайте необходимо расширение для браузера. Убедитесь, что оно у Вас включено или установите его." +
+                "<p><a href='https://www.cryptopro.ru/sites/default/files/products/cades/extensions/firefox_cryptopro_extension_latest.xpi'>Скачать расширение</a></p>" +
+                "</div>";
+            document.getElementsByTagName("Body")[0].appendChild(ovr);
+            document.getElementById("cadesplugin_close_install").addEventListener('click', function () {
+                plugin_loaded_error("Плагин недоступен");
+                document.getElementById("cadesplugin_ovr").style.visibility = 'hidden';
+            });
+
+            ovr.addEventListener('click', function () {
+                plugin_loaded_error("Плагин недоступен");
+                document.getElementById("cadesplugin_ovr").style.visibility = 'hidden';
+            });
+            ovr.style.visibility = "visible";
+        }
+    }
+
+    function firefox_or_safari_nmcades_onload() {
+        // noinspection JSUnresolvedVariable
+        if (window.cadesplugin_extension_loaded_callback) {
+            window.cadesplugin_extension_loaded_callback();
+        }
+        isFireFoxExtensionLoaded = true;
+        // noinspection JSUnresolvedVariable,JSUnresolvedFunction
+        cpcsp_chrome_nmcades.check_chrome_plugin(plugin_loaded, plugin_loaded_error);
+    }
+
+    function load_js_script(url, successFunc, errorFunc) {
+        var script = document.createElement("script");
+        script.setAttribute("type", "text/javascript");
+        script.setAttribute("src", url);
+        script.onerror = errorFunc;
+        script.onload = successFunc;
+        document.getElementsByTagName("head")[0].appendChild(script);
+    }
+
+    function nmcades_api_onload() {
+        if (!isIE() && !isFireFox && !isSafari) {
+            // noinspection JSUnresolvedVariable
+            if (window.cadesplugin_extension_loaded_callback) {
+                window.cadesplugin_extension_loaded_callback();
+            }
+        }
+        window.postMessage("cadesplugin_echo_request", "*");
+        window.addEventListener("message", function (event) {
+            if (typeof (event.data) !== "string" || !event.data.match("cadesplugin_loaded")) {
+                return;
+            }
+            if (cadesplugin_loaded_event_recieved) {
+                return;
+            }
+            if (isFireFox || isSafari) {
+                // Для Firefox, Сафари вместе с сообщением cadesplugin_loaded прилетает url для загрузки nmcades_plugin_api.js
+                var url = event.data.substring(event.data.indexOf("url:") + 4);
+                if (!url.match("^(moz|safari)-extension://[a-zA-Z0-9/_-]+/nmcades_plugin_api.js$")) {
+                    cpcsp_console_log(cadesplugin.LOG_LEVEL_ERROR, "Bad url \"" + url + "\" for load CryptoPro Extension for CAdES Browser plug-in");
+                    plugin_loaded_error();
+                    return;
+                }
+                load_js_script(url, firefox_or_safari_nmcades_onload, plugin_loaded_error);
+            } else {
+                // noinspection JSUnresolvedVariable,JSUnresolvedFunction
+                cpcsp_chrome_nmcades.check_chrome_plugin(plugin_loaded, plugin_loaded_error);
+            }
+            cadesplugin_loaded_event_recieved = true;
+        }, false);
+    }
+
+    // Загружаем расширения для Chrome, Opera, YaBrowser, FireFox, Edge, Safari
+    function load_extension() {
+        if (isFireFox || isSafari) {
+            // вызываем callback руками т.к. нам нужно узнать ID расширения. Он уникальный для браузера.
+            nmcades_api_onload();
+            return;
+        }
+        var operaUrl = "chrome-extension://epebfcehmdedogndhlcacafjaacknbcm/nmcades_plugin_api.js";
+        var manifestv2Url = "chrome-extension://iifchhfnnmpdbibifmljnfjhpififfog/nmcades_plugin_api.js";
+        var manifestv3Url = "chrome-extension://pfhgbfnnjiafkhfdkmpiflachepdcjod/nmcades_plugin_api.js";
+        if (isYandex) {
+            // в асинхронном варианте для Yandex пробуем подключить расширения по очереди
+            load_js_script(operaUrl, nmcades_api_onload, function () {
+                load_js_script(manifestv2Url, nmcades_api_onload, function () {
+                    load_js_script(manifestv3Url, nmcades_api_onload, plugin_loaded_error);
+                });
+            });
+            return;
+        }
+        if (isOpera) {
+            // в Opera порядок такой, т.к. расширение Chrome manifestv2 не исправить
+            load_js_script(manifestv2Url, nmcades_api_onload, function () {
+                load_js_script(operaUrl, nmcades_api_onload, function () {
+                    load_js_script(manifestv3Url, nmcades_api_onload, plugin_loaded_error);
+                });
+            });
+            return;
+        }
+        // для Chrome, Chromium, Chromium Edge расширение из Chrome store
+        load_js_script(manifestv2Url, nmcades_api_onload, function () {
+            load_js_script(manifestv3Url, nmcades_api_onload, plugin_loaded_error);
+        });
+    }
+
+    //Загружаем плагин для NPAPI
+    function load_npapi_plugin() {
+        var elem = document.createElement('object');
+        elem.setAttribute("id", "cadesplugin_object");
+        elem.setAttribute("type", "application/x-cades");
+        elem.setAttribute("style", "visibility: hidden");
+        document.getElementsByTagName("body")[0].appendChild(elem);
+        pluginObject = document.getElementById("cadesplugin_object");
+        if (isIE()) {
+            var elem1 = document.createElement('object');
+            elem1.setAttribute("id", "certEnrollClassFactory");
+            elem1.setAttribute("classid", "clsid:884e2049-217d-11da-b2a4-000e7bbb2b09");
+            elem1.setAttribute("style", "visibility: hidden");
+            document.getElementsByTagName("body")[0].appendChild(elem1);
+            var elem2 = document.createElement('object');
+            elem2.setAttribute("id", "webClassFactory");
+            elem2.setAttribute("classid", "clsid:B04C8637-10BD-484E-B0DA-B8A039F60024");
+            elem2.setAttribute("style", "visibility: hidden");
+            document.getElementsByTagName("body")[0].appendChild(elem2);
+        }
+    }
+
+    //Отправляем событие что все ок.
+    function plugin_loaded() {
+        plugin_resolved = 1;
+        if (window.cadesplugin_plugin_loaded_callback)
+            window.cadesplugin_plugin_loaded_callback();
+        if (canPromise) {
+            plugin_resolve();
+        } else {
+            window.postMessage("cadesplugin_loaded", "*");
+        }
+    }
+
+    //Отправляем событие что сломались.
+    function plugin_loaded_error(msg) {
+        if (typeof (msg) === 'undefined' || typeof (msg) === 'object') {
+            msg = "Плагин недоступен";
+        }
+        plugin_resolved = 1;
+        if (canPromise) {
+            plugin_reject(msg);
+        } else {
+            window.postMessage("cadesplugin_load_error", "*");
+        }
+    }
+
+    //проверяем что у нас хоть какое то событие ушло, и если не уходило кидаем еще раз ошибку
+    function check_load_timeout() {
+        if (plugin_resolved === 1) {
+            return;
+        }
+        if (isFireFox && !isFireFoxExtensionLoaded) {
+            show_firefox_missing_extension_dialog();
+        }
+        plugin_resolved = 1;
+        if (window.cadesplugin_timeout_failed_callback)
+            window.cadesplugin_timeout_failed_callback();
+        if (canPromise) {
+            plugin_reject("Истекло время ожидания загрузки плагина");
+        } else {
+            window.postMessage("cadesplugin_load_error", "*");
+        }
+    }
+
+    function check_npapi_plugin() {
+        try {
+            CreateObject("CAdESCOM.About");
+            plugin_loaded();
+        } catch (err) {
+            document.getElementById("cadesplugin_object").style.display = 'none';
+            // Объект создать не удалось, проверим, установлен ли
+            // вообще плагин. Такая возможность есть не во всех браузерах
+            // noinspection JSDeprecatedSymbols
+            var mimetype = window.navigator.mimeTypes["application/x-cades"];
+            if (mimetype) {
+                // noinspection JSDeprecatedSymbols
+                var plugin = mimetype.enabledPlugin;
+                if (plugin) {
+                    plugin_loaded_error("Плагин загружен, но не создаются обьекты");
+                } else {
+                    plugin_loaded_error("Ошибка при загрузке плагина");
+                }
+            } else {
+                plugin_loaded_error("Плагин недоступен");
+            }
+        }
+    }
+
+    // Проверяем работает ли плагин
+    function check_plugin_working() {
+        var div = document.createElement("div");
+        div.innerHTML = "<!--[if lt IE 9]><i></i><![endif]-->";
+        var isIeLessThan9 = (div.getElementsByTagName("i").length === 1);
+        if (isIeLessThan9) {
+            plugin_loaded_error("Internet Explorer версии 8 и ниже не поддерживается");
+            return;
+        }
+
+        if (isNativeMessageSupported()) {
+            load_extension();
+        } else if (!canPromise) {
+            window.addEventListener("message", function (event) {
+                if (event.data !== "cadesplugin_echo_request") {
+                    return;
+                }
+                load_npapi_plugin();
+                check_npapi_plugin();
+            }, false);
+        } else {
+            if (document.readyState === "complete") {
+                load_npapi_plugin();
+                check_npapi_plugin();
+            } else {
+                window.addEventListener("load", function (event) {
+                    load_npapi_plugin();
+                    check_npapi_plugin();
+                }, false);
+            }
+        }
+    }
+
+    function set_pluginObject(obj) {
+        pluginObject = obj;
+    }
+
+    function is_capilite_enabled() {
+        // noinspection JSUnresolvedVariable
+        return ((typeof (cadesplugin.EnableInternalCSP) !== 'undefined') && cadesplugin.EnableInternalCSP);
+    }
+
+    function set_load_timeout() {
+        // noinspection JSUnresolvedVariable
+        if (window.cadesplugin_load_timeout) {
+            window.setTimeout(check_load_timeout, window.cadesplugin_load_timeout);
+        } else {
+            window.setTimeout(check_load_timeout, 20000);
+        }
+    }
+
+    // noinspection JSUnusedLocalSymbols
+    var onVisibilityChange = function (event) {
+        if (document.hidden === false) {
+            document.removeEventListener("visibilitychange", onVisibilityChange);
+            set_load_timeout();
+            check_plugin_working();
+        }
+    };
+
+    //Export
+    cadesplugin.JSModuleVersion = "2.4.5";
+    cadesplugin.async_spawn = async_spawn;
+    cadesplugin.set = set_pluginObject;
+    cadesplugin.set_log_level = set_log_level;
+    cadesplugin.get_extension_version = get_extension_version;
+    cadesplugin.get_extension_id = get_extension_id;
+    cadesplugin.getLastError = getLastError;
+    cadesplugin.is_capilite_enabled = is_capilite_enabled;
+
+    if (isNativeMessageSupported()) {
+        cadesplugin.CreateObjectAsync = CreateObjectAsync;
+        cadesplugin.ReleasePluginObjects = ReleasePluginObjects;
+    }
+
+    if (!isNativeMessageSupported()) {
+        cadesplugin.CreateObject = CreateObject;
+    }
+
+    set_constantValues();
+
+    cadesplugin.current_log_level = cadesplugin.LOG_LEVEL_ERROR;
+    window.cadesplugin = cadesplugin;
+    if (isSafari && document.hidden) {
+        document.addEventListener("visibilitychange", onVisibilityChange);
+        return;
+    }
+    set_load_timeout();
+    check_plugin_working();
+}());

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -125,6 +125,30 @@ def _admin_warning_triangle_html(*, title: str, color: str = "#f0ad4e") -> str:
     )
 
 
+def _admin_lu_lo_sheets_column_html(obj) -> str:
+    """Ссылки на сгенерированные листы утверждения и ознакомления."""
+    parts = []
+    approval = getattr(obj, "approval_document", None)
+    if approval:
+        parts.append(
+            format_html(
+                '<a href="{}" target="_blank" rel="noopener noreferrer">Лист утверждения</a>',
+                approval.url,
+            )
+        )
+    acquaintance = getattr(obj, "acquaintance_document", None)
+    if acquaintance:
+        parts.append(
+            format_html(
+                '<a href="{}" target="_blank" rel="noopener noreferrer">Лист ознакомления</a>',
+                acquaintance.url,
+            )
+        )
+    if not parts:
+        return "—"
+    return mark_safe("<br>".join(str(p) for p in parts))
+
+
 def _universal_rkd_planned_review_show_warning(validity_date, *, days: int) -> bool:
     if not validity_date:
         return False
@@ -1340,7 +1364,7 @@ def _rkd_docs_section_header(title: str):
 class UniversalRKDSignatureInline(admin.TabularInline):
     model = UniversalRKDSignature
     extra = 0
-    fields = ("role", "signed_by", "signature_file")
+    fields = ("role", "signed_by", "signature_file", "signed_at")
     autocomplete_fields = ("signed_by",)
     verbose_name = "Подпись"
     verbose_name_plural = "Подписание документа"
@@ -1351,6 +1375,14 @@ class UniversalRKDAdmin(admin.ModelAdmin):
     change_form_template = "admin/blog/universal_rkd_category_change_form.html"
     change_list_template = "admin/blog/universalrkd/change_list.html"
     form = UniversalRKDForm
+    actions = ["send_to_approval_action"]
+
+    @admin.action(description="Отправить на согласование")
+    def send_to_approval_action(self, request, queryset):
+        ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=rkd&ids={ids}"
+        return redirect(url)
+
     list_display = (
         "rkd_post_column",
         "rkd_specification_section",
@@ -1359,6 +1391,7 @@ class UniversalRKDAdmin(admin.ModelAdmin):
         "desig_document",
         "name",
         "rkd_documents_column",
+        "display_lu_lo_sheets",
         "quantity",
         "note",
         "rkd_planned_review_warning",
@@ -1389,13 +1422,6 @@ class UniversalRKDAdmin(admin.ModelAdmin):
                     obj.document_uploaded_file.url,
                 )
             )
-        if obj.approval_document:
-            parts.append(
-                format_html(
-                    '<a href="{}" target="_blank" rel="noopener noreferrer">Лист утверждения</a>',
-                    obj.approval_document.url,
-                )
-            )
         if obj.attestation_document:
             parts.append(
                 format_html(
@@ -1406,6 +1432,10 @@ class UniversalRKDAdmin(admin.ModelAdmin):
         if not parts:
             return "—"
         return mark_safe("<br>".join(str(p) for p in parts))
+
+    @admin.display(description="ЛУ/ЛО")
+    def display_lu_lo_sheets(self, obj):
+        return _admin_lu_lo_sheets_column_html(obj)
 
     @admin.display(
         description="Оповещение о пересмотре",
@@ -1497,6 +1527,15 @@ class UniversalRKDAdmin(admin.ModelAdmin):
                 "fields": (
                     "approval_document",
                     "approval_source",
+                ),
+            },
+        ),
+        (
+            None,
+            {
+                "description": _rkd_docs_section_header("Лист ознакомления"),
+                "fields": (
+                    "acquaintance_document",
                 ),
             },
         ),
@@ -1648,6 +1687,14 @@ class UniversalRKDAdmin(admin.ModelAdmin):
         html += _row(
             "Лист утверждения — исходник (DOCX)",
             getattr(obj, "approval_source", None),
+            with_sep=True,
+            uploaded_by=last_editor,
+            uploaded_at=changed_at,
+            action_label="изменил",
+        )
+        html += _row(
+            "Лист ознакомления (PDF)",
+            getattr(obj, "acquaintance_document", None),
             with_sep=True,
             uploaded_by=last_editor,
             uploaded_at=changed_at,
@@ -1825,6 +1872,7 @@ class UniversalRKDAdmin(admin.ModelAdmin):
 
     _PDF_FILE_FIELDS = {
         "approval_document",
+        "acquaintance_document",
         "attestation_document",
     }
     _DOCX_FILE_FIELDS = {
@@ -4160,6 +4208,14 @@ class WorkAssignmentSubtaskAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         user = request.user
+        old_executor_id = None
+        if change:
+            old_executor_id = (
+                WorkAssignmentSubtask.objects
+                .filter(pk=obj.pk)
+                .values_list("executor_id", flat=True)
+                .first()
+            )
         if not change:
             if user.is_authenticated:
                 obj.author = user
@@ -4176,6 +4232,17 @@ class WorkAssignmentSubtaskAdmin(admin.ModelAdmin):
             )
 
         super().save_model(request, obj, form, change)
+
+        if obj.executor_id and obj.executor_id != old_executor_id and obj.executor_id != user.id:
+            from approvals.services import notify
+            from approvals.models import Notification
+            notify(
+                obj.executor,
+                "Вас назначили исполнителем подзадачи",
+                text=f"«{obj.task or obj}» (РЗ: {obj.work_assignment}).",
+                url=reverse("admin:blog_workassignmentsubtask_change", args=[obj.pk]),
+                kind=Notification.KIND_WORK,
+            )
 
 
 @admin.register(WorkAssignment)
@@ -4327,11 +4394,13 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         user = request.user
+        old_executor_id = None
 
         if change:
             try:
                 old = WorkAssignment.objects.get(pk=obj.pk)
                 old_status = old.control_status
+                old_executor_id = old.executor_id
                 cur = obj.version or "0"
                 try:
                     version_to = str(int(cur) + 1)
@@ -4373,6 +4442,17 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 obj.wa_number = next_wa_number_for_post(obj.post, exclude_pk=obj.pk)
 
         super().save_model(request, obj, form, change)
+
+        if obj.executor_id and obj.executor_id != old_executor_id and obj.executor_id != user.id:
+            from approvals.services import notify
+            from approvals.models import Notification
+            notify(
+                obj.executor,
+                "Вас назначили исполнителем рабочего задания",
+                text=f"«{obj.name or obj.task or obj}» — срок: {obj.target_deadline:%d.%m.%Y}.",
+                url=reverse("admin:blog_workassignment_change", args=[obj.pk]),
+                kind=Notification.KIND_WORK,
+            )
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
@@ -4489,6 +4569,9 @@ class WorkAssignmentDeadlineChangeAdmin(admin.ModelAdmin):
 class ProcessAdmin(admin.ModelAdmin):
     list_display = ("name", "code")
     search_fields = ("name", "code")
+
+    def has_module_permission(self, request):
+        return False
 
 
 class RouteProcessInline(admin.TabularInline):
@@ -4745,6 +4828,13 @@ class IndependentDocumentAcceptSignatureInline(admin.TabularInline):
 
 @admin.register(SharedRepository)
 class SharedRepositoryAdmin(admin.ModelAdmin):
+    actions = ["send_to_approval_action"]
+
+    @admin.action(description="Отправить на согласование")
+    def send_to_approval_action(self, request, queryset):
+        ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=independent&ids={ids}"
+        return redirect(url)
 
     list_display = [
         'display_document_title',
@@ -4755,6 +4845,7 @@ class SharedRepositoryAdmin(admin.ModelAdmin):
         'display_date_of_change',
         'display_version',
         'display_uploaded_file',
+        'display_lu_lo_sheets',
         'display_document_purpose',
         'display_note',
         'display_related_documents',
@@ -4781,6 +4872,8 @@ class SharedRepositoryAdmin(admin.ModelAdmin):
         'last_editor',
         'author',
         'display_related_qms_documents_list',
+        'approval_document',
+        'acquaintance_document',
     ]
 
     filter_horizontal = ['related_documents']
@@ -4805,6 +4898,8 @@ class SharedRepositoryAdmin(admin.ModelAdmin):
                 'approval',
                 'signature_approval',
                 'date_approval',
+                'approval_document',
+                'acquaintance_document',
             )
         }),
         ('Ознакомление', {
@@ -4957,6 +5052,10 @@ class SharedRepositoryAdmin(admin.ModelAdmin):
         return "—"
 
     display_uploaded_file.short_description = 'Файл'
+
+    @admin.display(description="ЛУ/ЛО")
+    def display_lu_lo_sheets(self, obj):
+        return _admin_lu_lo_sheets_column_html(obj)
 
     def display_document_purpose(self, obj):
         """Отображение назначения документа"""
@@ -5331,6 +5430,14 @@ class QMSDocumentAcceptSignatureInline(admin.TabularInline):
 
 @admin.register(QMSDocument)
 class QMSDocumentAdmin(admin.ModelAdmin):
+    actions = ["send_to_approval_action"]
+
+    @admin.action(description="Отправить на согласование")
+    def send_to_approval_action(self, request, queryset):
+        ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=qms&ids={ids}"
+        return redirect(url)
+
     list_display = [
         'display_document_title',
         'display_category',
@@ -5339,6 +5446,7 @@ class QMSDocumentAdmin(admin.ModelAdmin):
         'display_date_approval',
         'display_accept',
         'display_uploaded_file',
+        'display_lu_lo_sheets',
         'display_review_date',
         'display_review_status',
         'document_purpose',
@@ -5367,6 +5475,8 @@ class QMSDocumentAdmin(admin.ModelAdmin):
         'last_editor',
         'author',
         'display_related_shared_documents_list',
+        'approval_document',
+        'acquaintance_document',
     ]
 
     filter_horizontal = ['related_documents']
@@ -5387,6 +5497,8 @@ class QMSDocumentAdmin(admin.ModelAdmin):
                 'approval',
                 'approval_signature',
                 'date_approval',
+                'approval_document',
+                'acquaintance_document',
             )
         }),
         ('Ознакомление', {
@@ -5534,6 +5646,10 @@ class QMSDocumentAdmin(admin.ModelAdmin):
 
     display_uploaded_file.short_description = 'Файл'
 
+    @admin.display(description="ЛУ/ЛО")
+    def display_lu_lo_sheets(self, obj):
+        return _admin_lu_lo_sheets_column_html(obj)
+
     def display_review_date(self, obj):
         """Отображение даты планового пересмотра"""
         if obj.review_date:
@@ -5638,6 +5754,14 @@ class AdministrativeOrderAcceptSignatureInline(admin.TabularInline):
 
 @admin.register(AdministrativeOrder)
 class AdministrativeOrderAdmin(admin.ModelAdmin):
+    actions = ["send_to_approval_action"]
+
+    @admin.action(description="Отправить на согласование")
+    def send_to_approval_action(self, request, queryset):
+        ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=order&ids={ids}"
+        return redirect(url)
+
     list_display = [
         'registration_number',
         'enterprise_display',
@@ -5647,7 +5771,8 @@ class AdministrativeOrderAdmin(admin.ModelAdmin):
         'scope_display',
         'status_display',
         'validity_date_warning',
-        'uploaded_file'
+        'uploaded_file',
+        'display_lu_lo_sheets',
     ]
 
     list_filter = [
@@ -5666,11 +5791,12 @@ class AdministrativeOrderAdmin(admin.ModelAdmin):
 
     readonly_fields = [
         'id',
-        #'registration_number',
         'author',
         'date_of_creation',
         'last_editor',
         'date_of_change',
+        'approval_document',
+        'acquaintance_document',
     ]
 
     inlines = [AdministrativeOrderAcceptSignatureInline]
@@ -5691,6 +5817,8 @@ class AdministrativeOrderAdmin(admin.ModelAdmin):
                 'approval',
                 'signature_approval',
                 'accept',
+                'approval_document',
+                'acquaintance_document',
             )
         }),
         ('Сроки', {
@@ -5848,6 +5976,10 @@ class AdministrativeOrderAdmin(admin.ModelAdmin):
         return "—"
 
     display_uploaded_file.short_description = 'Файл'
+
+    @admin.display(description="ЛУ/ЛО")
+    def display_lu_lo_sheets(self, obj):
+        return _admin_lu_lo_sheets_column_html(obj)
 
 class DocumentTemplateAcceptSignatureInline(admin.TabularInline):
     """Inline для множественных подписей ознакомления шаблонов"""

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -38,6 +38,8 @@ from crm.forms import TicketCommentForm, SupportTicketForm
 from enterprise_asset_management.models import (
     WorkEquipment,
     WorkEquipmentFile,
+    WorkEquipmentRepair,
+    WorkEquipmentRepairFile,
     TransportVehicle,
     ProductionArea,
     ProductionAreaFile,
@@ -195,6 +197,10 @@ def _build_version_diff_block(*, old_obj, new_obj, model_cls, skip_fields,
         if str(old_val) != str(new_val):
             old_disp = old_val if old_val not in (None, "") else "—"
             new_disp = new_val if new_val not in (None, "") else "—"
+            if field.choices:
+                choices_map = dict(field.choices)
+                old_disp = choices_map.get(old_val, old_disp)
+                new_disp = choices_map.get(new_val, new_disp)
             diff_parts.append(f"- {field.verbose_name}: «{old_disp}» → «{new_disp}»")
 
     if not diff_parts:
@@ -224,6 +230,29 @@ def _render_version_diff(text: str) -> str:
         escaped,
     )
     return escaped.replace("\n", "<br>")
+
+
+_WA_STATUS_CIRCLE = {
+    'in_progress': ('#2196F3', None,      'В работе'),
+    'on_time':     ('#4CAF50', None,      'Выполнено в срок'),
+    'rescheduled': ('#4CAF50', '#FF9800', 'Выполнено с переносом сроков'),
+    'partial':     ('#9C27B0', None,      'Выполнено частично'),
+    'not_done':    ('#9E9E9E', None,      'Не выполнено (Отменено)'),
+}
+
+
+def _render_status_circle(status):
+    if not status:
+        return "—"
+    color1, color2, label = _WA_STATUS_CIRCLE.get(status, ('#cccccc', None, status))
+    bg = f"conic-gradient({color1} 50%, {color2} 50%)" if color2 else color1
+    return format_html(
+        '<span style="display:inline-flex;align-items:center;gap:6px;">'
+        '<span style="width:10px;height:10px;border-radius:50%;'
+        'background:{};flex-shrink:0;display:inline-block;"></span>'
+        '{}</span>',
+        bg, label,
+    )
 
 
 class RequiredFileGenericFormSet(BaseGenericInlineFormSet):
@@ -950,17 +979,17 @@ class PostAdmin(admin.ModelAdmin):
         UniversalRKDInline,
     ]
 
-    @admin.display(description="Общее наименование группы изделий (продуктов)")
+    @admin.display(description="Наименование группы разработок")
     def group_name_display(self, obj):
         value = (obj.product_group.name if obj and obj.product_group_id else "") or ""
         return format_html('<span id="pg_val_name">{}</span>', value or "—")
 
-    @admin.display(description="Общее обозначение группы изделий (продуктов)")
+    @admin.display(description="Обозначение группы разработок")
     def group_designation_display(self, obj):
         value = (obj.product_group.designation if obj and obj.product_group_id else "") or ""
         return format_html('<span id="pg_val_designation">{}</span>', value or "—")
 
-    @admin.display(description="Основное назначение изделия (продукта)")
+    @admin.display(description="Основное назначение группы разработок")
     def group_main_purpose_display(self, obj):
         value = (obj.product_group.main_purpose if obj and obj.product_group_id else "") or ""
         return format_html('<span id="pg_val_main_purpose">{}</span>', value or "—")
@@ -1067,7 +1096,7 @@ class PostAdmin(admin.ModelAdmin):
         qs = super().get_queryset(request)
         return qs.select_related("product_group")
 
-    @admin.display(description="Общая группа разработок", ordering="product_group__name")
+    @admin.display(description="Группа разработок", ordering="product_group__name")
     def product_group_link(self, obj):
         if not obj or not obj.product_group_id:
             return "—"
@@ -1447,6 +1476,7 @@ class UniversalRKDAdmin(admin.ModelAdmin):
                     "status",
                     "related_documents",
                     "develop_org",
+                    "comment",
                 )
             },
         ),
@@ -1481,13 +1511,12 @@ class UniversalRKDAdmin(admin.ModelAdmin):
             },
         ),
         (
-            "Дополнительно",
+            "Данные для спецификации",
             {
                 "fields": (
                     "quantity",
                     "note",
                     "weight",
-                    "comment",
                 )
             },
         ),
@@ -1752,6 +1781,24 @@ class UniversalRKDAdmin(admin.ModelAdmin):
         if not obj.current_responsible_id:
             obj.current_responsible = request.user
         super().save_model(request, obj, form, change)
+
+    def save_related(self, request, form, formsets, change):
+        super().save_related(request, form, formsets, change)
+        obj = form.instance
+        if not obj.pk:
+            return
+        if obj.attestation_document or obj.attestation_source:
+            return
+        if not obj.signatures.exists():
+            return
+        try:
+            from blog.services import UniversalRKDService
+            UniversalRKDService.generate_approval_sheet(obj, request.user)
+        except Exception as e:
+            messages.warning(
+                request,
+                f"Лист утверждения не обновлён: {e}",
+            )
 
     @admin.display(description="Сравнение версий")
     def version_diff_display(self, obj):
@@ -3182,7 +3229,9 @@ admin.site.register(Call, CallAdmin)
 # EAM (СИСТЕМА УПРАВЛЕНИЕ АКТИВАМИ)
 class WorkEquipmentFileInline(admin.TabularInline):
     model = WorkEquipmentFile
-    extra = 1
+    extra = 0
+    fields = ("title", "file", "note")
+    verbose_name_plural = "Сопроводительные документы"
 
 class TransportVehicleFileInline(admin.TabularInline):
     model = TransportVehicleFile
@@ -3192,6 +3241,30 @@ class ProductionAreaFileInline(admin.TabularInline):
     model = ProductionAreaFile
     extra = 1
 
+class WorkEquipmentRepairFileInline(admin.TabularInline):
+    model = WorkEquipmentRepairFile
+    extra = 1
+    verbose_name_plural = "Документы, чеки"
+
+
+class WorkEquipmentRepairInline(admin.StackedInline):
+    model = WorkEquipmentRepair
+    extra = 0
+    show_change_link = True
+    verbose_name = "Ремонт / ТО"
+    verbose_name_plural = "РЕМОНТЫ / ТО"
+    fields = (
+        "repair_date",
+        "description",
+        "next_planned_date",
+        "planned_works_description",
+    )
+    readonly_fields = ()
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).select_related("work_equipment")
+
+
 class TransportRepairFileInline(admin.TabularInline):
     model = TransportRepairFile
     extra = 1
@@ -3199,19 +3272,41 @@ class TransportRepairFileInline(admin.TabularInline):
 # Рабочее оборудование
 @admin.register(WorkEquipment)
 class WorkEquipmentAdmin(admin.ModelAdmin):
-    list_display = ("name_type", "serial_number_link", "measuring_device_display", "next_calibration_date_display", "calibration_warning", "calibration_date_warning", "workstation", "status")
+    list_display = (
+        "name_type",
+        "serial_number_link",
+        "measuring_device_display",
+        "next_calibration_date_display",
+        "calibration_warning",
+        "calibration_date_warning",
+        "workstation",
+        "status",
+        "documents_column",
+        "repairs_link",
+    )
     list_filter = ("measuring_device",)
     search_fields = ("name_type", "serial_number", "workstation")
-    readonly_fields = ("date_of_creation", "date_of_change")
-    exclude = ("version_diff",)
-    inlines = [WorkEquipmentFileInline]
+    readonly_fields = ("author", "last_editor", "date_of_creation", "date_of_change", "version_diff_display")
+    inlines = [WorkEquipmentFileInline, WorkEquipmentRepairInline]
+
+    _VERSION_SKIP_FIELDS = frozenset({
+        "id", "version", "version_diff",
+        "author", "last_editor",
+        "date_of_creation", "date_of_change",
+    })
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).prefetch_related("files", "repairs")
+
+    def formfield_for_dbfield(self, db_field, request, **kwargs):
+        if db_field.name == "calibration_info":
+            kwargs["widget"] = forms.Textarea(attrs={"rows": 3})
+        return super().formfield_for_dbfield(db_field, request, **kwargs)
 
     @admin.display(description="Средство измерений")
     def measuring_device_display(self, obj):
         if obj.measuring_device:
-            return mark_safe(
-                '<img src="/static/admin/img/icon-yes.svg" alt="Да">'
-            )
+            return mark_safe('<img src="/static/admin/img/icon-yes.svg" alt="Да">')
         return "—"
 
     def next_calibration_date_display(self, obj):
@@ -3222,12 +3317,44 @@ class WorkEquipmentAdmin(admin.ModelAdmin):
     next_calibration_date_display.short_description = "Дата плановой поверки"
     next_calibration_date_display.admin_order_field = "next_calibration_date"
 
+    @admin.display(description="Сопроводительные документы")
+    def documents_column(self, obj):
+        docs = [d for d in obj.files.all() if d.file and d.file.name]
+        if not docs:
+            return "—"
+        parts = []
+        for d in docs:
+            label = d.title or d.file.name.split("/")[-1]
+            parts.append(format_html(
+                '<div style="margin:0 0 4px 0;line-height:1.35;">'
+                '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>'
+                '</div>',
+                d.file.url,
+                label,
+            ))
+        return mark_safe("".join(str(p) for p in parts))
+
+    @admin.display(description="Сравнение версий")
+    def version_diff_display(self, obj):
+        if not obj:
+            return "—"
+        return mark_safe(_render_version_diff(obj.version_diff or ""))
+
+    @admin.display(description="Ремонты / ТО")
+    def repairs_link(self, obj):
+        url = (
+            reverse("admin:enterprise_asset_management_workequipmentrepair_changelist")
+            + f"?work_equipment__id__exact={obj.pk}"
+        )
+        return format_html('<a href="{}">{} ({})</a>', url, "Ремонты / ТО", obj.repairs.count())
+
     def get_fieldsets(self, request, obj=None):
         main_fields = (
             "name_type",
             "serial_number",
             "measuring_device",
             "next_calibration_date",
+            "calibration_info",
             "calibration_required",
             "planned_calibration_date",
             "workstation",
@@ -3237,27 +3364,88 @@ class WorkEquipmentAdmin(admin.ModelAdmin):
         if obj is None:
             return (
                 (None, {"fields": main_fields}),
-                ("Ответственные", {"fields": ("current_responsible",)}),
-                ("Версия", {"fields": ("version",)}),
-                ("Системная информация", {"fields": ("date_of_creation", "date_of_change", "note")}),
+                ("Сопроводительные документы", {"fields": ("note",)}),
+                ("Системные данные", {"fields": (
+                    "current_responsible",
+                    "version",
+                    "version_diff_display",
+                    "date_of_creation",
+                    "date_of_change",
+                )}),
             )
         return (
             (None, {"fields": main_fields}),
-            ("Ответственные", {"fields": ("author", "last_editor", "current_responsible")}),
-            ("Версия", {"fields": ("version",)}),
-            ("Системная информация", {"fields": ("date_of_creation", "date_of_change", "note")}),
+            ("Сопроводительные документы", {"fields": ("note",)}),
+            ("Ремонты / ТО", {"fields": ("repairs_all_link",)}),
+            ("Системные данные", {"fields": (
+                "author",
+                "last_editor",
+                "current_responsible",
+                "version",
+                "version_diff_display",
+                "date_of_creation",
+                "date_of_change",
+            )}),
         )
 
     def get_readonly_fields(self, request, obj=None):
+        base = ("date_of_creation", "date_of_change", "version_diff_display")
         if obj is None:
-            return self.readonly_fields
-        return ("author", "last_editor") + tuple(self.readonly_fields)
+            return base
+        return ("author", "last_editor", "repairs_all_link") + base
+
+    @admin.display(description="")
+    def repairs_all_link(self, obj):
+        if not obj or not obj.pk:
+            return "—"
+        url = (
+            reverse("admin:enterprise_asset_management_workequipmentrepair_changelist")
+            + f"?work_equipment__id__exact={obj.pk}"
+        )
+        count = obj.repairs.count()
+        return format_html(
+            '<a href="{}" class="button" style="'
+            'display:inline-block;padding:4px 12px;border-radius:4px;'
+            'background:#417690;color:#fff;text-decoration:none;font-size:12px;">'
+            '📋 Открыть все ремонты / ТО ({})</a>',
+            url, count,
+        )
 
     def save_model(self, request, obj, form, change):
         if not change:
             obj.author = request.user
+            obj.version = "1"
+            obj.version_diff = "Стартовая версия"
+        else:
+            old = WorkEquipment.objects.get(pk=obj.pk)
+            try:
+                new_version = str(int(old.version) + 1)[:3]
+            except (ValueError, TypeError):
+                new_version = old.version
+            block = _build_version_diff_block(
+                old_obj=old,
+                new_obj=obj,
+                model_cls=WorkEquipment,
+                skip_fields=self._VERSION_SKIP_FIELDS,
+                user=request.user if request.user.is_authenticated else None,
+                version_to=new_version,
+            )
+            if block:
+                obj.version = new_version
+                obj.version_diff = ((old.version_diff or "").rstrip() + "\n\n" + block).strip()
         obj.last_editor = request.user
         super().save_model(request, obj, form, change)
+
+    def save_formset(self, request, form, formset, change):
+        instances = formset.save(commit=False)
+        for obj in instances:
+            if not obj.pk:
+                obj.author = request.user
+            obj.last_editor = request.user
+            obj.save()
+        for obj in formset.deleted_objects:
+            obj.delete()
+        formset.save_m2m()
 
 # Кастомные колонки
     def _warning_triangle_svg(self, *, title: str, color: str) -> str:
@@ -3311,6 +3499,68 @@ class WorkEquipmentAdmin(admin.ModelAdmin):
         return "—"
 
     calibration_date_warning.short_description = "Срок калибровки истекает"
+
+# Ремонты / ТО рабочего оборудования
+@admin.register(WorkEquipmentRepair)
+class WorkEquipmentRepairAdmin(admin.ModelAdmin):
+
+    list_display = (
+        "work_equipment",
+        "repair_date",
+        "description",
+        "next_planned_date",
+        "author",
+        "date_of_creation",
+    )
+
+    list_filter = (
+        "repair_date",
+        "work_equipment",
+    )
+
+    search_fields = (
+        "work_equipment__name_type",
+        "work_equipment__serial_number",
+        "description",
+    )
+
+    readonly_fields = ("author", "last_editor", "date_of_creation", "date_of_change")
+
+    inlines = [WorkEquipmentRepairFileInline]
+
+    fieldsets = (
+        ("Основная информация", {
+            "fields": (
+                "work_equipment",
+                "repair_date",
+                "description",
+            )
+        }),
+        ("Планово-предупредительные работы", {
+            "fields": (
+                "next_planned_date",
+                "planned_works_description",
+            )
+        }),
+        ("Системная информация", {
+            "fields": (
+                "author",
+                "last_editor",
+                "date_of_creation",
+                "date_of_change",
+            )
+        }),
+    )
+
+    def has_module_permission(self, request):
+        return False
+
+    def save_model(self, request, obj, form, change):
+        if not change:
+            obj.author = request.user
+        obj.last_editor = request.user
+        super().save_model(request, obj, form, change)
+
 
 # Транспорт
 @admin.register(TransportVehicle)
@@ -3659,6 +3909,13 @@ class WorkAssignmentSubtaskInline(admin.TabularInline):
     extra = 0
     can_delete = True
     show_change_link = False
+    verbose_name = "Подзадача"
+    verbose_name_plural = mark_safe(
+        'ПОДЗАДАЧИ'
+        '<div style="font-weight:normal;font-size:12px;color:#c8c8c8;margin-top:4px;">'
+        '💡 Для добавления сохраните основную задачу через «Сохранить и продолжить редактировать»'
+        '</div>'
+    )
     fields = (
         "parent_rz_display",
         "subtask_code_link",
@@ -3666,6 +3923,9 @@ class WorkAssignmentSubtaskInline(admin.TabularInline):
         "target_deadline",
         "task_preview",
         "criteria_preview",
+        "control_status_colored",
+        "overdue_flag",
+        "comment_preview",
     )
     readonly_fields = (
         "parent_rz_display",
@@ -3674,6 +3934,9 @@ class WorkAssignmentSubtaskInline(admin.TabularInline):
         "target_deadline",
         "task_preview",
         "criteria_preview",
+        "control_status_colored",
+        "overdue_flag",
+        "comment_preview",
     )
 
     def has_add_permission(self, request, obj=None):
@@ -3716,6 +3979,29 @@ class WorkAssignmentSubtaskInline(admin.TabularInline):
             '<div class="subtask-inline-cell">' + linebreaksbr(t) + "</div>"
         )
 
+    @admin.display(description="Статус")
+    def control_status_colored(self, obj):
+        return _render_status_circle(obj.control_status)
+
+    @admin.display(description="Просрочено?")
+    def overdue_flag(self, obj):
+        active = obj.control_status in (None, 'in_progress')
+        if not active:
+            return "—"
+        deadline = obj.hard_deadline or obj.target_deadline
+        if deadline and timezone.localdate() > deadline:
+            return "⚠️"
+        return "—"
+
+    @admin.display(description="Комментарий")
+    def comment_preview(self, obj):
+        t = (obj.comment or "").strip()
+        if not t:
+            return "—"
+        return mark_safe(
+            '<div class="subtask-inline-cell">' + linebreaksbr(t) + "</div>"
+        )
+
 
 @admin.register(WorkAssignmentSubtask)
 class WorkAssignmentSubtaskAdmin(admin.ModelAdmin):
@@ -3727,7 +4013,11 @@ class WorkAssignmentSubtaskAdmin(admin.ModelAdmin):
         extra["title"] = "Добавить подзадачу рабочего задания"
         return super().add_view(request, form_url, extra_context=extra)
 
-    list_display = ("id", "work_assignment", "task_short", "target_deadline", "executor")
+    list_display = (
+        "id", "work_assignment", "task_short",
+        "target_deadline", "executor",
+        "control_status_colored", "comment_short",
+    )
     search_fields = ("task", "work_assignment__name")
     readonly_fields = ("date_of_creation", "date_of_change")
 
@@ -3757,11 +4047,12 @@ class WorkAssignmentSubtaskAdmin(admin.ModelAdmin):
             },
         ),
         (
-            "Контроль и результат",
+            "Статус выполнения / Результат",
             {
                 "fields": (
                     "control_status",
                     "control_date",
+                    "comment",
                     "result_description",
                     "uploaded_file",
                 )
@@ -3838,6 +4129,15 @@ class WorkAssignmentSubtaskAdmin(admin.ModelAdmin):
         t = (obj.task or "").strip().replace("\n", " ")
         return (t[:60] + "...") if len(t) > 60 else (t or "—")
 
+    @admin.display(description="Статус выполнения / Результат", ordering="control_status")
+    def control_status_colored(self, obj):
+        return _render_status_circle(obj.control_status)
+
+    @admin.display(description="Комментарий")
+    def comment_short(self, obj):
+        t = (obj.comment or "").strip().replace("\n", " ")
+        return (t[:60] + "...") if len(t) > 60 else (t or "—")
+
     def get_changeform_initial_data(self, request):
         initial = super().get_changeform_initial_data(request)
         if request.user.is_authenticated:
@@ -3885,12 +4185,12 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
     list_display = (
         'wa_code_column',
         'name', 'author', 'executor', 'post',
-        'effective_deadline_readonly',
         'overdue_flag',
-        'version',
+        'control_status_colored',
+        'control_date',
         'target_deadline', 'hard_deadline',
-        'control_status', 'control_date',
-        'deadline_version', 'reschedule_count', # служебные
+        'version',
+        'deadline_version', 'reschedule_count',
     )
     list_display_links = ('wa_code_column', 'name')
     ordering = ('post__wa_code', 'wa_number', 'pk')
@@ -3906,8 +4206,12 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
     def wa_code_column(self, obj):
         return obj.wa_full_code or '—'
 
-    readonly_fields = ('date_of_creation','date_of_change',
-                       'effective_deadline_readonly','deadline_version','reschedule_count')
+    readonly_fields = (
+        'author', 'last_editor',
+        'date_of_creation', 'date_of_change',
+        'version', 'version_diff_display',
+        'deadline_version', 'reschedule_count',
+    )
 
     inlines = [DeadlineChangeInline, WorkAssignmentSubtaskInline, WorkAssignmentAttachmentInline]
 
@@ -3915,7 +4219,6 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         ('Основная информация', {
             'fields': (
                 'name', 'executor', 'category', 'post',
-                'author', 'current_responsible', 'version',
                 'task', 'acceptance_criteria',
             )
         }),
@@ -3924,15 +4227,18 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 'target_deadline', 'hard_deadline',
                 ('time_window_start', 'time_window_end'),
                 'conditional_deadline',
-                'effective_deadline_readonly',
             )
         }),
-        ('Контроль выполнения', {
+        ('Статус выполнения / Результат', {
             'fields': ('control_status', 'control_date', 'result_description')
         }),
-        ('Системная информация', {
-            'fields': ('route', 'date_of_creation', 'date_of_change', 'last_editor',
-                       'deadline_version','reschedule_count')
+        ('Системные данные', {
+            'fields': (
+                'author', 'last_editor', 'current_responsible',
+                'version', 'version_diff_display',
+                'date_of_creation', 'date_of_change',
+                'route', 'deadline_version', 'reschedule_count',
+            )
         }),
     )
 
@@ -4009,21 +4315,63 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         post_id = request.GET.get("post")
         if post_id:
             initial["post"] = post_id
-        if request.user.is_authenticated:
-            initial.setdefault("author", request.user.pk)
-            initial.setdefault("last_editor", request.user.pk)
         return initial
+
+    _VERSION_SKIP_FIELDS = frozenset({
+        "id", "version", "version_diff",
+        "author_id", "last_editor_id",
+        "date_of_creation", "date_of_change",
+        "wa_number", "deadline_version", "reschedule_count",
+        "name",
+    })
 
     def save_model(self, request, obj, form, change):
         user = request.user
-        if not change and user.is_authenticated:
+
+        if change:
+            try:
+                old = WorkAssignment.objects.get(pk=obj.pk)
+                old_status = old.control_status
+                cur = obj.version or "0"
+                try:
+                    version_to = str(int(cur) + 1)
+                except ValueError:
+                    version_to = cur + "+"
+                diff = _build_version_diff_block(
+                    old_obj=old,
+                    new_obj=obj,
+                    model_cls=WorkAssignment,
+                    skip_fields=self._VERSION_SKIP_FIELDS,
+                    user=user,
+                    version_to=version_to,
+                )
+                if diff:
+                    existing = (obj.version_diff or "").strip()
+                    obj.version_diff = (existing + "\n\n" + diff).strip() if existing else diff
+                    obj.version = version_to
+            except WorkAssignment.DoesNotExist:
+                old_status = None
+
+            obj.last_editor = user
+
+            # Автоматически проставляем control_date при смене статуса
+            if obj.control_status and obj.control_status != old_status:
+                obj.control_date = timezone.localdate()
+        else:
             obj.author = user
             obj.last_editor = user
+            # Для новых записей: статус "В работе" и дата фиксации = сегодня
+            if not obj.control_status:
+                obj.control_status = "in_progress"
+            if not obj.control_date:
+                obj.control_date = timezone.localdate()
+
         if obj.post_id:
             from .helpers import assign_wa_code_to_post, next_wa_number_for_post
             assign_wa_code_to_post(obj.post)
             if not obj.wa_number:
                 obj.wa_number = next_wa_number_for_post(obj.post, exclude_pk=obj.pk)
+
         super().save_model(request, obj, form, change)
 
     def get_queryset(self, request):
@@ -4039,11 +4387,16 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
             )
         )
 
+        # Просрочено: нет статуса ИЛИ статус «В работе» + срок прошёл
         qs = qs.annotate(
             is_overdue=Case(
                 When(
-                    Q(control_status__isnull=True) & Q(effective_deadline_db__lt=today),
-                    then=True
+                    Q(control_status__isnull=True) | Q(control_status="in_progress"),
+                    then=Case(
+                        When(effective_deadline_db__lt=today, then=True),
+                        default=False,
+                        output_field=BooleanField(),
+                    ),
                 ),
                 default=False,
                 output_field=BooleanField(),
@@ -4052,13 +4405,20 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
 
         return qs
 
-    def effective_deadline_readonly(self, obj):
-        return obj.effective_deadline
-    effective_deadline_readonly.short_description = "Эффективный срок"
+    @admin.display(description="Статус выполнения / Результат", ordering="control_status")
+    def control_status_colored(self, obj):
+        return _render_status_circle(obj.control_status)
 
+    @admin.display(description="Просрочено?")
     def overdue_flag(self, obj):
-        return "—" if obj.control_status else ("⚠️" if obj.is_overdue else "—")
-    overdue_flag.short_description = "Просрочено?"
+        active = obj.control_status in (None, 'in_progress')
+        return "⚠️" if (active and obj.is_overdue) else "—"
+
+    @admin.display(description="История изменений")
+    def version_diff_display(self, obj):
+        if not obj:
+            return "—"
+        return mark_safe(_render_version_diff(obj.version_diff or ""))
 
     def get_urls(self):
         urls = super().get_urls()

--- a/blog/models.py
+++ b/blog/models.py
@@ -2521,6 +2521,15 @@ class UniversalRKD(models.Model):
         verbose_name="Удостоверяющий лист: исходник (DOCX)",
         help_text="Допустимый формат: DOCX.",
     )
+    acquaintance_document = models.FileField(
+        upload_to="blog/universal_rkd/acquaintance/%Y/%m/",
+        max_length=500,
+        blank=True,
+        null=True,
+        validators=[FileExtensionValidator(allowed_extensions=["pdf"])],
+        verbose_name="Лист ознакомления (PDF)",
+        help_text="Формируется автоматически при подписании шагов «Ознакомление».",
+    )
 
     checked_by = models.ForeignKey(
         User,
@@ -2752,6 +2761,9 @@ class UniversalRKDSignature(models.Model):
         null=True,
         verbose_name="Файл подписи",
     )
+    signed_at = models.DateField("Дата подписания", null=True, blank=True)
+    cert_cn = models.CharField("ФИО из сертификата ЭЦП", max_length=500, blank=True)
+    cert_issuer = models.CharField("Удостоверяющий центр (УЦ)", max_length=500, blank=True)
 
     class Meta:
         verbose_name = "Подпись документа"
@@ -2760,6 +2772,57 @@ class UniversalRKDSignature(models.Model):
 
     def __str__(self):
         return f"{self.get_role_display()} — {self.signed_by or '—'}"
+
+
+class UniversalRKDAcknowledgment(models.Model):
+    """Строка листа ознакомления по шагу маршрута с ЭЦП."""
+
+    rkd = models.ForeignKey(
+        UniversalRKD,
+        on_delete=models.CASCADE,
+        related_name="acknowledgments",
+        verbose_name="Документ РКД",
+    )
+    process = models.ForeignKey(
+        "approvals.ApprovalProcess",
+        on_delete=models.CASCADE,
+        related_name="acknowledgments",
+        verbose_name="Согласование",
+    )
+    task = models.OneToOneField(
+        "approvals.ApprovalTask",
+        on_delete=models.CASCADE,
+        related_name="acknowledgment",
+        verbose_name="Задача",
+    )
+    department = models.ForeignKey(
+        "approvals.Department",
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        verbose_name="Отдел",
+    )
+    position = models.CharField("Должность", max_length=150, blank=True)
+    signed_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="rkd_acknowledgments",
+        verbose_name="Подписант",
+    )
+    signed_at = models.DateField("Дата", null=True, blank=True)
+    cert_cn = models.CharField("ФИО из сертификата ЭЦП", max_length=500, blank=True)
+    cert_issuer = models.CharField("Удостоверяющий центр (УЦ)", max_length=500, blank=True)
+    step_order = models.PositiveSmallIntegerField("Порядок в маршруте", default=0)
+
+    class Meta:
+        verbose_name = "Ознакомление (лист)"
+        verbose_name_plural = "Ознакомления (лист)"
+        ordering = ("step_order", "pk")
+
+    def __str__(self):
+        return f"{self.position or self.department or '—'} — {self.signed_by or '—'}"
 
 
 class Shipment(models.Model):

--- a/blog/models.py
+++ b/blog/models.py
@@ -95,19 +95,19 @@ class ProductGroup(models.Model):
     name = models.CharField(
         max_length=200,
         unique=True,
-        verbose_name="Общее наименование группы изделий (продуктов)",
+        verbose_name="Наименование группы разработок",
     )
     designation = models.CharField(
         max_length=100,
         blank=True,
         default="",
-        verbose_name="Общее обозначение группы изделий (продуктов)",
+        verbose_name="Обозначение группы разработок",
     )
     main_purpose = models.TextField(
         max_length=2000,
         blank=True,
         default="",
-        verbose_name="Основное назначение изделия (продукта)",
+        verbose_name="Основное назначение группы разработок",
     )
     author = models.ForeignKey(
         User,
@@ -135,7 +135,7 @@ class ProductGroup(models.Model):
     )
 
     class Meta:
-        verbose_name = "Общая группа разработок"
+        verbose_name = "Группа разработок"
         verbose_name_plural = "Группы разработок (модификаций)"
         ordering = ("name",)
 
@@ -157,7 +157,7 @@ class ProductGroupDocument(models.Model):
         ProductGroup,
         on_delete=models.CASCADE,
         related_name="documents",
-        verbose_name="Общая группа разработок",
+        verbose_name="Группа разработок",
     )
     title = models.CharField(
         max_length=500,
@@ -257,7 +257,7 @@ class Post(models.Model):
         null=True,
         blank=True,
         related_name="posts",
-        verbose_name="Общая группа разработок",
+        verbose_name="Группа разработок",
     )
     group_modification_features = models.TextField(
         max_length=2000,
@@ -1606,10 +1606,11 @@ class WorkAssignment(models.Model):
     ]
 
     TEMP_STATUS_CHOICES = [
+        ('in_progress', 'В работе'),
         ('on_time', 'Выполнено в срок'),
         ('rescheduled', 'Выполнено с переносом сроков'),
         ('partial', 'Выполнено частично'),
-        ('not_done', 'Не выполнено'),
+        ('not_done', 'Не выполнено (Отменено)'),
     ]
 
     # базовые поля
@@ -1638,7 +1639,10 @@ class WorkAssignment(models.Model):
         verbose_name="Текущий ответственный"
     )
     version = models.CharField(max_length=3, blank=True, null=True, verbose_name="Версия")
-    task = models.TextField(verbose_name="Задача")
+    task = models.TextField(
+        verbose_name="Задача",
+        help_text="Декомпозиция задачи: в разделе «ПОДЗАДАЧИ» (доступна через «Сохранить и продолжить редактировать»)",
+    )
     acceptance_criteria = models.TextField(default='---', verbose_name="Критерий выполнения")
     uploaded_file = models.FileField(upload_to='uploads/', blank = True, verbose_name="Загружаемый файл")
 
@@ -1657,8 +1661,13 @@ class WorkAssignment(models.Model):
     conditional_deadline = models.CharField("Условный дедлайн", max_length=1000, blank=True)
     #uploaded_file = models.FileField(upload_to='uploads/', blank = True, verbose_name="Приложение к РЗ")
 
+    version_diff = models.TextField(
+        "Сравнение версий",
+        blank=True,
+        default="Стартовая версия",
+    )
     control_status = models.CharField(
-        "Контроль выполнения - статус",
+        "Статус выполнения / Результат",
         max_length=20,
         null=True,
         blank=True,
@@ -1792,7 +1801,6 @@ class WorkAssignmentSubtask(models.Model):
         User,
         on_delete=models.CASCADE,
         null=True,
-        blank=True,
         related_name="subtask_executed_assignments",
         verbose_name="Исполнитель",
     )
@@ -1842,13 +1850,18 @@ class WorkAssignmentSubtask(models.Model):
     time_window_end = models.DateField("Временное окно: по", null=True, blank=True)
     conditional_deadline = models.CharField("Условный дедлайн", max_length=1000, blank=True)
     control_status = models.CharField(
-        "Контроль выполнения - статус",
+        "Статус выполнения / Результат",
         max_length=20,
         null=True,
         blank=True,
         choices=WorkAssignment.TEMP_STATUS_CHOICES,
     )
     control_date = models.DateField("Дата фиксации статуса", null=True, blank=True)
+    comment = models.TextField(
+        "Комментарий",
+        blank=True,
+        null=True,
+    )
 
     class Meta:
         verbose_name = "Подзадача рабочего задания"
@@ -2661,6 +2674,24 @@ class UniversalRKD(models.Model):
             if not self.signature_checked:
                 raise ValidationError({"signature_checked": "Для статуса «Выпущен» приложите подпись проверки."})
 
+        has_approval = bool(self.approval_document) or bool(self.approval_source)
+        has_attestation = bool(self.attestation_document) or bool(self.attestation_source)
+        if has_approval and has_attestation:
+            mutual_error = (
+                "К документу можно прикрепить только что-то одно: «Лист утверждения» или "
+                "«Удостоверяющий лист». Удалите файлы из ненужного блока."
+            )
+            errors = {}
+            if self.approval_document:
+                errors["approval_document"] = mutual_error
+            if self.approval_source:
+                errors["approval_source"] = mutual_error
+            if self.attestation_document:
+                errors["attestation_document"] = mutual_error
+            if self.attestation_source:
+                errors["attestation_source"] = mutual_error
+            raise ValidationError(errors)
+
     def save(self, *args, **kwargs):
         if self.post_id:
             post = self.post
@@ -2683,11 +2714,14 @@ class UniversalRKDSignature(models.Model):
     """Подписи к документу РКД (проверил / согласовал / утвердил)."""
 
     ROLE_CHOICES = [
+        ("designer", "Разработал"),
         ("scheme", "Проверил (схемотехнические требования)"),
         ("it", "Проверил IT (требования, связанные с клиент-серверным ПО)"),
         ("3d", "Проверил 3D (требования, связанные с 3D-печатью)"),
-        ("tt", "Проверил ТТ (технические требования)"),
-        ("nk", "Проверил НК (нормоконтроль)"),
+        ("metro", "Проверил (метрологический контроль)"),
+        ("tk", "Т. контроль (технологический контроль)"),
+        ("lead", "Проверил (руководитель разработки)"),
+        ("nk", "Н. контроль (нормоконтроль)"),
         ("agreed", "Согласовал"),
         ("approved", "Утвердил"),
     ]

--- a/blog/services.py
+++ b/blog/services.py
@@ -1,5 +1,13 @@
+import base64
+import os
+from datetime import datetime
+
+from django.core.files.base import ContentFile
 from django.db import transaction
+from django.template.loader import render_to_string
 from django.utils import timezone
+from weasyprint import HTML
+
 from .models import WorkAssignment, WorkAssignmentDeadlineChange
 
 class WorkAssignmentService:
@@ -66,14 +74,76 @@ class WorkAssignmentService:
 
         # 6) служебные поля
         assignment.reschedule_count = (assignment.reschedule_count or 0) + 1
-        assignment.control_status = "changed"
-        assignment.control_date = eff
 
         # 7) сохранить
         assignment.save(update_fields=[
             "target_deadline","hard_deadline","time_window_start","time_window_end",
-            "reschedule_count","control_status","control_date","deadline_version",
+            "reschedule_count","deadline_version",
             "date_of_change","last_editor"
         ])
 
         return assignment
+
+
+class UniversalRKDService:
+    _IMAGE_MIMES = {
+        "png": "image/png",
+        "jpg": "image/jpeg",
+        "jpeg": "image/jpeg",
+        "gif": "image/gif",
+        "bmp": "image/bmp",
+        "webp": "image/webp",
+    }
+
+    @staticmethod
+    def generate_approval_sheet(rkd, user):
+        """Генерирует PDF «Лист утверждения» и сохраняет в rkd.approval_document."""
+        signatures = rkd.signatures.select_related("signed_by").order_by("role")
+
+        sig_data = []
+        for sig in signatures:
+            img_b64 = None
+            date_str = ""
+            if sig.signature_file:
+                try:
+                    ext = sig.signature_file.name.rsplit(".", 1)[-1].lower()
+                    mime = UniversalRKDService._IMAGE_MIMES.get(ext)
+                    if mime:
+                        with sig.signature_file.open("rb") as f:
+                            raw = f.read()
+                        img_b64 = f"data:{mime};base64,{base64.b64encode(raw).decode()}"
+                    try:
+                        mtime = os.path.getmtime(sig.signature_file.path)
+                        date_str = datetime.fromtimestamp(mtime).strftime("%d.%m.%Y")
+                    except Exception:
+                        pass
+                except Exception:
+                    pass
+            sig_data.append({
+                "role": sig.get_role_display(),
+                "signed_by": (
+                    sig.signed_by.get_full_name() or sig.signed_by.username
+                    if sig.signed_by else "—"
+                ),
+                "img_b64": img_b64,
+                "date": date_str,
+            })
+
+        context = {
+            "rkd": rkd,
+            "signatures": sig_data,
+            "generated_at": timezone.now(),
+        }
+
+        html_string = render_to_string("pdf/approval_sheet_template.html", context)
+        pdf_bytes = HTML(string=html_string).write_pdf()
+
+        desig = (rkd.desig_document or str(rkd.pk)).replace("/", "_").replace(" ", "_")
+        filename = f"ЛУ_{desig}.pdf"
+
+        if rkd.approval_document:
+            rkd.approval_document.delete(save=False)
+
+        rkd.approval_document.save(filename, ContentFile(pdf_bytes), save=True)
+
+        return filename

--- a/blog/services.py
+++ b/blog/services.py
@@ -1,12 +1,5 @@
-import base64
-import os
-from datetime import datetime
-
-from django.core.files.base import ContentFile
 from django.db import transaction
-from django.template.loader import render_to_string
 from django.utils import timezone
-from weasyprint import HTML
 
 from .models import WorkAssignment, WorkAssignmentDeadlineChange
 
@@ -86,64 +79,12 @@ class WorkAssignmentService:
 
 
 class UniversalRKDService:
-    _IMAGE_MIMES = {
-        "png": "image/png",
-        "jpg": "image/jpeg",
-        "jpeg": "image/jpeg",
-        "gif": "image/gif",
-        "bmp": "image/bmp",
-        "webp": "image/webp",
-    }
-
     @staticmethod
     def generate_approval_sheet(rkd, user):
-        """Генерирует PDF «Лист утверждения» и сохраняет в rkd.approval_document."""
-        signatures = rkd.signatures.select_related("signed_by").order_by("role")
+        from approvals.sheet_service import generate_approval_sheet
+        return generate_approval_sheet(rkd)
 
-        sig_data = []
-        for sig in signatures:
-            img_b64 = None
-            date_str = ""
-            if sig.signature_file:
-                try:
-                    ext = sig.signature_file.name.rsplit(".", 1)[-1].lower()
-                    mime = UniversalRKDService._IMAGE_MIMES.get(ext)
-                    if mime:
-                        with sig.signature_file.open("rb") as f:
-                            raw = f.read()
-                        img_b64 = f"data:{mime};base64,{base64.b64encode(raw).decode()}"
-                    try:
-                        mtime = os.path.getmtime(sig.signature_file.path)
-                        date_str = datetime.fromtimestamp(mtime).strftime("%d.%m.%Y")
-                    except Exception:
-                        pass
-                except Exception:
-                    pass
-            sig_data.append({
-                "role": sig.get_role_display(),
-                "signed_by": (
-                    sig.signed_by.get_full_name() or sig.signed_by.username
-                    if sig.signed_by else "—"
-                ),
-                "img_b64": img_b64,
-                "date": date_str,
-            })
-
-        context = {
-            "rkd": rkd,
-            "signatures": sig_data,
-            "generated_at": timezone.now(),
-        }
-
-        html_string = render_to_string("pdf/approval_sheet_template.html", context)
-        pdf_bytes = HTML(string=html_string).write_pdf()
-
-        desig = (rkd.desig_document or str(rkd.pk)).replace("/", "_").replace(" ", "_")
-        filename = f"ЛУ_{desig}.pdf"
-
-        if rkd.approval_document:
-            rkd.approval_document.delete(save=False)
-
-        rkd.approval_document.save(filename, ContentFile(pdf_bytes), save=True)
-
-        return filename
+    @staticmethod
+    def generate_acquaintance_sheet(rkd, process):
+        from approvals.sheet_service import generate_acquaintance_sheet
+        return generate_acquaintance_sheet(rkd, process)

--- a/enterprise_asset_management/models.py
+++ b/enterprise_asset_management/models.py
@@ -28,6 +28,12 @@ class WorkEquipment(models.Model):
     )
     measuring_device = models.BooleanField("Средство измерений", default=False)
     next_calibration_date = models.DateField("Дата плановой поверки", blank=True, null=True)
+    calibration_info = models.TextField(
+        "Сведения о поверке",
+        max_length=500,
+        blank=True,
+        null=True,
+    )
     calibration_required = models.BooleanField("Требуется калибровка", default=False)
     planned_calibration_date = models.DateField("Дата плановой калибровки", blank=True, null=True)
     workstation = models.CharField("Рабочее место", max_length=100, blank=True, null=True)
@@ -64,9 +70,9 @@ class WorkEquipment(models.Model):
         null=True,
     )
 
-    note = models.CharField(
+    note = models.TextField(
         "Примечание",
-        max_length=300,
+        max_length=2000,
         blank=True,
         null=True,
     )
@@ -126,15 +132,108 @@ class WorkEquipmentFile(models.Model):
         related_name="files",
         verbose_name="Рабочее оборудование",
     )
-    file = models.FileField("Файл", upload_to="work_equipment_files/", validators=[validate_file_size])
-    uploaded_at = models.DateTimeField("Дата загрузки", default=timezone.now)
+    title = models.CharField(
+        "Название и обозначение документа",
+        max_length=500,
+        blank=True,
+        default="",
+    )
+    file = models.FileField(
+        "Файл",
+        upload_to="work_equipment_files/",
+        validators=[validate_file_size],
+    )
+    note = models.TextField(
+        "Примечание",
+        max_length=5000,
+        blank=True,
+        default="",
+    )
 
     class Meta:
         verbose_name = "Сопроводительный документ"
         verbose_name_plural = "Сопроводительные документы"
+        ordering = ("pk",)
 
     def __str__(self):
-        return f"Файл для: {self.work_equipment}"
+        return self.title or (self.file.name.split("/")[-1] if self.file else f"Документ для: {self.work_equipment}")
+
+
+class WorkEquipmentRepair(models.Model):
+    """
+    Ремонты / ТО рабочего оборудования
+    """
+
+    work_equipment = models.ForeignKey(
+        WorkEquipment,
+        on_delete=models.CASCADE,
+        related_name="repairs",
+        verbose_name="Рабочее оборудование",
+    )
+    repair_date = models.DateField("Дата ремонта / ТО")
+    description = models.TextField("Описание выполненных работ", max_length=5000)
+
+    # --- Планово-предупредительные работы ---
+    next_planned_date = models.DateField(
+        "Дата следующих планово-предупредительных работ",
+        blank=True,
+        null=True,
+    )
+    planned_works_description = models.TextField(
+        "Описание планово-предупредительных работ",
+        max_length=500,
+        blank=True,
+        default="",
+    )
+
+    author = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name="work_equipment_repair_author",
+        verbose_name="Автор",
+        null=True,
+        blank=True,
+    )
+    last_editor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name="work_equipment_repair_last_editor",
+        verbose_name="Последний редактор",
+        null=True,
+        blank=True,
+    )
+    date_of_creation = models.DateTimeField("Дата и время создания", default=timezone.now)
+    date_of_change = models.DateTimeField("Дата и время последнего изменения", auto_now=True)
+
+    class Meta:
+        verbose_name = "Ремонт / ТО"
+        verbose_name_plural = "Ремонты / ТО"
+        ordering = ("-repair_date",)
+
+    def __str__(self):
+        return f"{self.work_equipment} — {self.repair_date}"
+
+
+class WorkEquipmentRepairFile(models.Model):
+    work_equipment_repair = models.ForeignKey(
+        WorkEquipmentRepair,
+        on_delete=models.CASCADE,
+        related_name="files",
+        verbose_name="Ремонт / ТО",
+    )
+    file = models.FileField(
+        "Файл",
+        upload_to="work_equipment_repair_files/",
+        validators=[validate_file_size],
+    )
+    uploaded_at = models.DateTimeField("Дата загрузки", default=timezone.now)
+
+    class Meta:
+        verbose_name = "Документ, чек"
+        verbose_name_plural = "Документы, чеки"
+
+    def __str__(self):
+        return f"Файл для: {self.work_equipment_repair}"
 
 
 class TransportVehicle(models.Model):

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     'crm',
     'shared_repository',
     'enterprise_asset_management',
+    'approvals',
 ]
 
 MIDDLEWARE = [
@@ -65,6 +66,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'approvals.context_processors.cabinet_badge',
             ],
         },
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 Django==5.1.2
 weasyprint==68.1
 xhtml2pdf==0.2.17
-
-asn1crypto
+asn1crypto==1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 Django==5.1.2
+asn1crypto

--- a/shared_repository/models.py
+++ b/shared_repository/models.py
@@ -146,6 +146,23 @@ class SharedRepository(models.Model):
         help_text='Подгружаем только один файл'
     )
 
+    approval_document = models.FileField(
+        upload_to='shared_repository/approval/%Y/%m/',
+        verbose_name='Лист утверждения (PDF)',
+        blank=True,
+        null=True,
+        validators=[validate_file_size],
+        help_text='Формируется автоматически при согласовании по маршруту.',
+    )
+    acquaintance_document = models.FileField(
+        upload_to='shared_repository/acquaintance/%Y/%m/',
+        verbose_name='Лист ознакомления (PDF)',
+        blank=True,
+        null=True,
+        validators=[validate_file_size],
+        help_text='Формируется автоматически при ознакомлении по маршруту.',
+    )
+
     # 16. Назначение документа
     document_purpose = models.TextField(
         max_length=5000,
@@ -620,6 +637,23 @@ class QMSDocument(models.Model):
         help_text='Основной файл документа (только один файл)'
     )
 
+    approval_document = models.FileField(
+        upload_to='qms_documents/approval/%Y/%m/',
+        verbose_name='Лист утверждения (PDF)',
+        blank=True,
+        null=True,
+        validators=[validate_file_size],
+        help_text='Формируется автоматически при согласовании по маршруту.',
+    )
+    acquaintance_document = models.FileField(
+        upload_to='qms_documents/acquaintance/%Y/%m/',
+        verbose_name='Лист ознакомления (PDF)',
+        blank=True,
+        null=True,
+        validators=[validate_file_size],
+        help_text='Формируется автоматически при ознакомлении по маршруту.',
+    )
+
     # 16. Назначение документа
     document_purpose = models.TextField(
         max_length=5000,
@@ -842,6 +876,22 @@ class AdministrativeOrder(models.Model):
         verbose_name='Загружаемый файл',
         validators=[validate_file_size],
         help_text='Основной файл приказа (только один файл)'
+    )
+    approval_document = models.FileField(
+        upload_to='administrative_orders/approval/%Y/%m/',
+        verbose_name='Лист утверждения (PDF)',
+        blank=True,
+        null=True,
+        validators=[validate_file_size],
+        help_text='Формируется автоматически при согласовании по маршруту.',
+    )
+    acquaintance_document = models.FileField(
+        upload_to='administrative_orders/acquaintance/%Y/%m/',
+        verbose_name='Лист ознакомления (PDF)',
+        blank=True,
+        null=True,
+        validators=[validate_file_size],
+        help_text='Формируется автоматически при ознакомлении по маршруту.',
     )
     app_uploaded_file = models.FileField(
         upload_to='administrative_orders/applications/%Y/%m/%d/',

--- a/templates/admin/approvals/cabinet.html
+++ b/templates/admin/approvals/cabinet.html
@@ -1,0 +1,382 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<style>
+  .cab-wrap { max-width: 1150px; }
+
+  .cab-nav {
+    margin-bottom:22px; padding:14px 16px 16px; border-radius:12px;
+    border:1px solid rgba(121,174,200,.22);
+    background:rgba(121,174,200,.04);
+    display:flex; flex-direction:column; gap:0;
+  }
+  .cab-nav-row {
+    display:grid; grid-template-columns:108px 1fr; gap:12px 16px;
+    align-items:center; padding:10px 0;
+  }
+  .cab-nav-row + .cab-nav-row { border-top:1px solid rgba(121,174,200,.12); }
+  .cab-nav-label {
+    font-size:11px; font-weight:700; letter-spacing:.04em;
+    text-transform:uppercase; color:#79aec8;
+    display:flex; align-items:center; gap:6px;
+  }
+  .cab-nav-label-icon { font-size:15px; line-height:1; }
+  .cab-tabs { display:grid; gap:8px; min-width:0; }
+  .cab-tabs--3 { grid-template-columns:repeat(3, minmax(0, 1fr)); }
+  .cab-tabs--2 { grid-template-columns:repeat(2, minmax(0, 1fr)); }
+  @media (max-width:720px) {
+    .cab-nav-row { grid-template-columns:1fr; gap:8px; }
+    .cab-tabs--3, .cab-tabs--2 { grid-template-columns:1fr; }
+  }
+  .cab-tab {
+    width:100%; padding:10px 14px; cursor:pointer; border-radius:8px;
+    border:1px solid rgba(121,174,200,.45);
+    background:transparent;
+    font-family:inherit; font-size:13px; font-weight:600; color:#9ec5d8;
+    display:flex; align-items:center; gap:10px;
+    appearance:none; -webkit-appearance:none;
+    transition:background .15s, border-color .15s, color .15s, box-shadow .15s;
+  }
+  .cab-tab:hover {
+    background:rgba(121,174,200,.14); color:#d4e8f2;
+    border-color:#79aec8;
+    box-shadow:0 2px 6px rgba(65,118,144,.2);
+  }
+  .cab-tab.active {
+    background:#417690;
+    border-color:#609ab6;
+    color:#fff;
+    box-shadow:0 3px 10px rgba(65,118,144,.45);
+  }
+  .cab-tab-icon { font-size:18px; line-height:1; flex-shrink:0; width:22px; text-align:center; }
+  .cab-tab.active .cab-tab-icon { transform:scale(1.05); }
+  .cab-tab-label { flex:1; text-align:left; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .cab-badge {
+    flex-shrink:0; min-width:20px; text-align:center;
+    background:#E53935; color:#fff; border-radius:999px;
+    padding:2px 7px; font-size:10px; font-weight:700; line-height:1.3;
+  }
+  .cab-tab.active .cab-badge { background:rgba(255,255,255,.92); color:#417690; }
+  .cab-badge.muted { background:rgba(121,174,200,.35); color:#e8f4fa; }
+  .cab-tab.active .cab-badge.muted { background:rgba(255,255,255,.85); color:#417690; }
+  .cab-panel { display:none; }
+  .cab-panel.active { display:block; }
+
+  .cab-card {
+    border:1px solid var(--hairline-color,#444); border-radius:10px; padding:14px 18px;
+    margin-bottom:12px; background:var(--darkened-bg,rgba(255,255,255,.02));
+    display:flex; justify-content:space-between; align-items:center; gap:16px; flex-wrap:wrap;
+  }
+  .cab-info { min-width:280px; flex:1; }
+  .cab-card .title { font-size:15px; font-weight:700; }
+  .cab-card .subtitle { font-size:13px; color:var(--body-quiet-color,#aaa); margin-top:2px; }
+  .cab-card .meta { font-size:12px; color:var(--body-quiet-color,#999); margin-top:6px; display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+  .cab-card .note { font-size:12px; margin-top:6px; padding:6px 10px; border-radius:6px; background:rgba(229,57,53,.10); }
+
+  .pill { border-radius:12px; padding:2px 10px; font-size:11px; font-weight:600; color:#fff; display:inline-block; }
+  .pill-blue { background:#2196F3; } .pill-green { background:#4CAF50; }
+  .pill-gray { background:#9E9E9E; } .pill-orange { background:#FB8C00; }
+  .pill-purple { background:#9C27B0; }
+  .pill-type { background:#607D8B; }
+
+  .cab-actions { display:flex; gap:8px; flex-wrap:wrap; }
+  .btn { padding:7px 15px; border-radius:6px; color:#fff; font-weight:600; font-size:13px; text-decoration:none; border:none; cursor:pointer; }
+  .btn-green { background:#4CAF50; } .btn-red { background:#E53935; }
+  .btn-blue { background:#2196F3; } .btn-gray { background:#777; }
+  .btn-ghost { background:transparent; color:#79aec8; border:1px solid #79aec8; }
+  .btn-doc { background:#5c6bc0; }
+
+  .cab-empty { padding:30px; text-align:center; color:var(--body-quiet-color,#999); font-style:italic; }
+  .cab-overdue { color:#E53935; font-weight:700; }
+  .notif.unread { background:rgba(33,150,243,.08); border-color:#2196F3; }
+
+  .issued-task {
+    margin-top:6px; padding:7px 0 7px 12px;
+    border-left:2px solid #79aec8;
+    font-size:13px; line-height:1.45; color:var(--body-quiet-color,#b0b0b0);
+    white-space:pre-line; word-break:break-word;
+  }
+</style>
+
+<div id="content-main" class="cab-wrap">
+
+  <nav class="cab-nav" aria-label="Разделы личного кабинета">
+    <div class="cab-nav-row">
+      <span class="cab-nav-label"><span class="cab-nav-label-icon">📑</span> Согласование</span>
+      <div class="cab-tabs cab-tabs--3">
+        <button type="button" class="cab-tab active" data-tab="sign">
+          <span class="cab-tab-icon" aria-hidden="true">✍️</span>
+          <span class="cab-tab-label">Подпись</span>
+          {% if sign_tasks %}<span class="cab-badge">{{ sign_tasks|length }}</span>{% endif %}
+        </button>
+        <button type="button" class="cab-tab" data-tab="ack">
+          <span class="cab-tab-icon" aria-hidden="true">👁️</span>
+          <span class="cab-tab-label">Ознакомление</span>
+          {% if ack_tasks %}<span class="cab-badge">{{ ack_tasks|length }}</span>{% endif %}
+        </button>
+        <button type="button" class="cab-tab" data-tab="fix">
+          <span class="cab-tab-icon" aria-hidden="true">✏️</span>
+          <span class="cab-tab-label">Доработка</span>
+          {% if fix_tasks %}<span class="cab-badge">{{ fix_tasks|length }}</span>{% endif %}
+        </button>
+      </div>
+    </div>
+    <div class="cab-nav-row">
+      <span class="cab-nav-label"><span class="cab-nav-label-icon">📋</span> Задания</span>
+      <div class="cab-tabs cab-tabs--2">
+        <button type="button" class="cab-tab" data-tab="work">
+          <span class="cab-tab-icon" aria-hidden="true">📥</span>
+          <span class="cab-tab-label">Мне назначено</span>
+          {% if my_work %}<span class="cab-badge muted">{{ my_work|length }}</span>{% endif %}
+        </button>
+        <button type="button" class="cab-tab" data-tab="issued">
+          <span class="cab-tab-icon" aria-hidden="true">📤</span>
+          <span class="cab-tab-label">Выданные</span>
+          {% if issued_work_active %}<span class="cab-badge muted">{{ issued_work_active }}</span>{% endif %}
+        </button>
+      </div>
+    </div>
+    <div class="cab-nav-row">
+      <span class="cab-nav-label"><span class="cab-nav-label-icon">📌</span> Прочее</span>
+      <div class="cab-tabs cab-tabs--2">
+        <button type="button" class="cab-tab" data-tab="docs">
+          <span class="cab-tab-icon" aria-hidden="true">📄</span>
+          <span class="cab-tab-label">Мои документы</span>
+          {% if my_docs %}<span class="cab-badge muted">{{ my_docs|length }}</span>{% endif %}
+        </button>
+        <button type="button" class="cab-tab" data-tab="notif">
+          <span class="cab-tab-icon" aria-hidden="true">🔔</span>
+          <span class="cab-tab-label">Уведомления</span>
+          {% if unread_count %}<span class="cab-badge">{{ unread_count }}</span>{% endif %}
+        </button>
+      </div>
+    </div>
+  </nav>
+
+  <div class="cab-panel active" data-panel="sign">
+    {% for t in sign_tasks %}
+    <div class="cab-card">
+      <div class="cab-info">
+        <div class="title">{{ t.doc_ctx.title }}</div>
+        {% if t.doc_ctx.subtitle %}<div class="subtitle">{{ t.doc_ctx.subtitle }}</div>{% endif %}
+        <div class="meta">
+          <span class="pill pill-type">{{ t.doc_ctx.type_label }}</span>
+          <span class="pill pill-orange">На подпись</span>
+          <span class="pill pill-blue">Шаг {{ t.process.current_order }}</span>
+          Ваша роль: <strong>{{ t.department }}</strong>
+          {% if t.is_recheck %} · ⟳ повторно{% endif %}
+        </div>
+      </div>
+      <div class="cab-actions">
+        {% if t.doc_ctx.file_url %}
+        <a class="btn btn-doc" href="{{ t.doc_ctx.file_url }}" target="_blank">Открыть документ</a>
+        {% endif %}
+        {% if t.doc_ctx.admin_url %}
+        <a class="btn btn-ghost" href="{{ t.doc_ctx.admin_url }}" target="_blank">Карточка</a>
+        {% endif %}
+        <a class="btn btn-green" href="{% url 'admin:approvals_task_sign' t.pk %}">✍ Подписать (ЭЦП)</a>
+        <a class="btn btn-red" href="{% url 'admin:approvals_task_reject' t.pk %}">Отклонить</a>
+      </div>
+    </div>
+    {% empty %}
+    <div class="cab-empty">Нет документов на согласование / подпись.</div>
+    {% endfor %}
+  </div>
+
+  <div class="cab-panel" data-panel="ack">
+    {% for t in ack_tasks %}
+    <div class="cab-card">
+      <div class="cab-info">
+        <div class="title">{{ t.doc_ctx.title }}</div>
+        {% if t.doc_ctx.subtitle %}<div class="subtitle">{{ t.doc_ctx.subtitle }}</div>{% endif %}
+        <div class="meta">
+          <span class="pill pill-type">{{ t.doc_ctx.type_label }}</span>
+          <span class="pill pill-purple">Ознакомление</span>
+          <span class="pill pill-blue">Шаг {{ t.process.current_order }}</span>
+          Отдел: <strong>{{ t.department }}</strong>
+        </div>
+      </div>
+      <div class="cab-actions">
+        {% if t.doc_ctx.file_url %}
+        <a class="btn btn-doc" href="{{ t.doc_ctx.file_url }}" target="_blank">Открыть документ</a>
+        {% endif %}
+        {% if t.doc_ctx.admin_url %}
+        <a class="btn btn-ghost" href="{{ t.doc_ctx.admin_url }}" target="_blank">Карточка</a>
+        {% endif %}
+        <a class="btn btn-green" href="{% url 'admin:approvals_task_sign' t.pk %}">✍ Подписать (ЭЦП)</a>
+      </div>
+    </div>
+    {% empty %}
+    <div class="cab-empty">Нет документов на ознакомление.</div>
+    {% endfor %}
+  </div>
+
+  <div class="cab-panel" data-panel="fix">
+    {% for t in fix_tasks %}
+    <div class="cab-card">
+      <div class="cab-info">
+        <div class="title">{{ t.doc_ctx.title }}</div>
+        {% if t.doc_ctx.subtitle %}<div class="subtitle">{{ t.doc_ctx.subtitle }}</div>{% endif %}
+        <div class="meta">
+          <span class="pill pill-type">{{ t.doc_ctx.type_label }}</span>
+          <span class="pill pill-orange">На доработку</span>
+          Вернул отдел: <strong>{{ t.department }}</strong>
+        </div>
+        {% if t.comment %}<div class="note">💬 Замечание: {{ t.comment }}</div>{% endif %}
+      </div>
+      <div class="cab-actions">
+        {% if t.doc_ctx.file_url %}
+        <a class="btn btn-doc" href="{{ t.doc_ctx.file_url }}" target="_blank">Открыть документ</a>
+        {% endif %}
+        {% if t.doc_ctx.admin_url %}
+        <a class="btn btn-ghost" href="{{ t.doc_ctx.admin_url }}" target="_blank">Карточка</a>
+        {% endif %}
+        <a class="btn btn-blue" href="{% url 'admin:approvals_task_resubmit' t.pk %}">Отправить на повторную проверку</a>
+      </div>
+    </div>
+    {% empty %}
+    <div class="cab-empty">Нет документов на доработке.</div>
+    {% endfor %}
+  </div>
+
+  <div class="cab-panel" data-panel="work">
+    {% for wa in my_work %}
+    <div class="cab-card">
+      <div class="cab-info">
+        <div class="title">{{ wa.name|default:wa }}</div>
+        <div class="meta">
+          {% if wa.post %}{{ wa.post }} · {% endif %}
+          Срок:
+          <span {% if wa.target_deadline < today %}class="cab-overdue"{% endif %}>
+            {{ wa.target_deadline|date:"d.m.Y" }}{% if wa.target_deadline < today %} (просрочено){% endif %}
+          </span>
+        </div>
+      </div>
+      <div class="cab-actions">
+        <a class="btn btn-gray" href="{% url 'admin:blog_workassignment_change' wa.pk %}">Открыть</a>
+      </div>
+    </div>
+    {% empty %}
+    <div class="cab-empty">Нет активных заданий, назначенных вам.</div>
+    {% endfor %}
+  </div>
+
+  <div class="cab-panel" data-panel="issued">
+    {% for wa in issued_work %}
+    <div class="cab-card">
+      <div class="cab-info">
+        <div class="title">
+          {% if wa.wa_full_code %}{{ wa.wa_full_code }}{% else %}{{ wa.name|default:"Рабочее задание" }}{% endif %}
+        </div>
+        {% if wa.task %}<div class="issued-task">{{ wa.task }}</div>{% endif %}
+        <div class="meta">
+          {% if wa.control_status == "on_time" %}<span class="pill pill-green">Выполнено в срок</span>
+          {% elif wa.control_status == "rescheduled" %}<span class="pill pill-orange">С переносом</span>
+          {% elif wa.control_status == "partial" %}<span class="pill pill-orange">Частично</span>
+          {% elif wa.control_status == "not_done" %}<span class="pill pill-gray">Не выполнено</span>
+          {% else %}<span class="pill pill-blue">В работе</span>{% endif %}
+          {% if wa.executor %}
+            Исполнитель: <strong>{{ wa.executor }}</strong>{% if wa.executor_id == wa.author_id %} (себе){% endif %}
+          {% endif %}
+          {% if wa.current_responsible_id != wa.executor_id %}
+            · Ответственный: <strong>{{ wa.current_responsible }}</strong>
+          {% endif %}
+          {% if wa.post %} · {{ wa.post }}{% endif %}
+        </div>
+        <div class="meta">
+          Срок:
+          <strong {% if not wa.control_status or wa.control_status == "in_progress" %}{% if wa.target_deadline < today %}class="cab-overdue"{% endif %}{% endif %}>
+            {{ wa.target_deadline|date:"d.m.Y" }}
+          </strong>
+          {% if not wa.control_status or wa.control_status == "in_progress" %}
+            {% if wa.target_deadline < today %} (просрочено){% endif %}
+          {% endif %}
+          · Создано: {{ wa.date_of_creation|date:"d.m.Y" }}
+          {% if wa.subtask_total %} · Подзадач: {{ wa.subtask_total }}{% endif %}
+          {% if wa.reschedule_count %} · Переносов: {{ wa.reschedule_count }}{% endif %}
+        </div>
+      </div>
+      <div class="cab-actions">
+        <a class="btn btn-gray" href="{% url 'admin:blog_workassignment_change' wa.pk %}">Открыть</a>
+      </div>
+    </div>
+    {% empty %}
+    <div class="cab-empty">У вас пока нет выданных заданий.</div>
+    {% endfor %}
+  </div>
+
+  <div class="cab-panel" data-panel="docs">
+    {% for p in my_docs %}
+    <div class="cab-card">
+      <div class="cab-info">
+        <div class="title">{{ p.doc_ctx.title }}</div>
+        <div class="meta">
+          <span class="pill pill-type">{{ p.doc_ctx.type_label }}</span>
+          {% if p.status == "approved" %}<span class="pill pill-green">Согласован</span>
+          {% elif p.status == "cancelled" %}<span class="pill pill-gray">Отменён</span>
+          {% else %}<span class="pill pill-blue">В процессе · шаг {{ p.current_order }}</span>{% endif %}
+          Маршрут: {{ p.route }}
+        </div>
+      </div>
+      <div class="cab-actions">
+        {% if p.doc_ctx.admin_url %}
+        <a class="btn btn-gray" href="{{ p.doc_ctx.admin_url }}">Карточка</a>
+        {% endif %}
+      </div>
+    </div>
+    {% empty %}
+    <div class="cab-empty">Вы не запускали согласований.</div>
+    {% endfor %}
+  </div>
+
+  <div class="cab-panel" data-panel="notif">
+    {% if notifications %}
+    <div style="margin-bottom:12px; display:flex; gap:8px; flex-wrap:wrap;">
+      <form method="post" action="{% url 'admin:approvals_notification_read_all' %}">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-gray">Отметить все прочитанными</button>
+      </form>
+      <form method="post" action="{% url 'admin:approvals_notification_clear_all' %}"
+            onsubmit="return confirm('Удалить все уведомления? Это действие нельзя отменить.');">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-red">Очистить уведомления</button>
+      </form>
+    </div>
+    {% endif %}
+    {% for n in notifications %}
+    <div class="cab-card notif {% if not n.is_read %}unread{% endif %}">
+      <div class="cab-info">
+        <div class="title">{% if not n.is_read %}🔵 {% endif %}{{ n.title }}</div>
+        {% if n.text %}<div class="subtitle">{{ n.text }}</div>{% endif %}
+        <div class="meta">{{ n.created_at|date:"d.m.Y H:i" }}</div>
+      </div>
+      <div class="cab-actions">
+        <a class="btn btn-blue" href="{% url 'admin:approvals_notification_open' n.pk %}">Открыть</a>
+      </div>
+    </div>
+    {% empty %}
+    <div class="cab-empty">Уведомлений нет.</div>
+    {% endfor %}
+  </div>
+
+</div>
+
+<script>
+  (function () {
+    var tabs = document.querySelectorAll(".cab-tab");
+    var panels = document.querySelectorAll(".cab-panel");
+    function activate(name) {
+      tabs.forEach(function (t) { t.classList.toggle("active", t.dataset.tab === name); });
+      panels.forEach(function (p) { p.classList.toggle("active", p.dataset.panel === name); });
+      try { localStorage.setItem("cabinetTab", name); } catch (e) {}
+    }
+    tabs.forEach(function (t) {
+      t.addEventListener("click", function () { activate(t.dataset.tab); });
+    });
+    var saved;
+    try { saved = localStorage.getItem("cabinetTab"); } catch (e) {}
+    var exists = saved && document.querySelector('.cab-panel[data-panel="' + saved + '"]');
+    if (exists) activate(saved);
+  })();
+</script>
+{% endblock %}

--- a/templates/admin/approvals/confirm_action.html
+++ b/templates/admin/approvals/confirm_action.html
@@ -1,0 +1,25 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<div id="content-main" style="max-width:700px;">
+
+  <div style="border:1px solid var(--hairline-color,#444);border-radius:10px;
+              padding:20px 24px;margin-bottom:20px;background:var(--darkened-bg,rgba(255,255,255,.02));">
+    <p style="font-size:16px;font-weight:600;margin:0 0 8px;">{{ message }}</p>
+  </div>
+
+  <form method="post" action="{{ action_url }}">
+    {% csrf_token %}
+    <div style="display:flex;gap:10px;">
+      <input type="submit" value="Подтвердить" class="default"
+             style="padding:10px 22px;font-size:14px;">
+      <a href="{{ back_url }}"
+         style="padding:10px 22px;font-size:14px;border-radius:4px;
+                border:1px solid #79aec8;color:#79aec8;text-decoration:none;">
+        ← Назад в кабинет
+      </a>
+    </div>
+  </form>
+
+</div>
+{% endblock %}

--- a/templates/admin/approvals/reject_task.html
+++ b/templates/admin/approvals/reject_task.html
@@ -1,0 +1,44 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<div id="content-main" style="max-width:700px;">
+
+  <div style="border:1px solid #E53935;border-radius:10px;
+              padding:16px 20px;margin-bottom:20px;background:rgba(229,57,53,.06);">
+    <div style="font-size:12px;font-weight:600;margin-bottom:4px;opacity:.85;">{{ doc_ctx.type_label }}</div>
+    <div style="font-size:15px;font-weight:700;">{{ doc_ctx.title }}</div>
+    {% if doc_ctx.subtitle %}
+    <div style="font-size:13px;color:var(--body-quiet-color,#aaa);margin-top:2px;">{{ doc_ctx.subtitle }}</div>
+    {% endif %}
+    <div style="font-size:12px;margin-top:6px;display:flex;gap:12px;flex-wrap:wrap;">
+      Отдел: <strong>{{ task.department }}</strong>
+      {% if doc_ctx.file_url %}
+      <a href="{{ doc_ctx.file_url }}" target="_blank">Открыть документ →</a>
+      {% endif %}
+      {% if doc_ctx.admin_url %}
+      <a href="{{ doc_ctx.admin_url }}" target="_blank">Карточка →</a>
+      {% endif %}
+    </div>
+  </div>
+
+  <p style="margin-bottom:8px;">
+    Опишите замечание — автор документа получит его в Личном кабинете и сможет внести правки.
+  </p>
+
+  <form method="post">
+    {% csrf_token %}
+    <table>{{ form.as_table }}</table>
+    <div style="display:flex;gap:10px;margin-top:16px;">
+      <input type="submit" value="Отклонить и отправить замечание"
+             style="background:#E53935;color:#fff;padding:10px 22px;
+                    border:none;border-radius:4px;font-size:14px;cursor:pointer;">
+      <a href="{{ back_url }}"
+         style="padding:10px 22px;font-size:14px;border-radius:4px;
+                border:1px solid #79aec8;color:#79aec8;text-decoration:none;">
+        ← Назад в кабинет
+      </a>
+    </div>
+  </form>
+
+</div>
+{% endblock %}

--- a/templates/admin/approvals/sign_document.html
+++ b/templates/admin/approvals/sign_document.html
@@ -1,0 +1,422 @@
+{% extends "admin/base_site.html" %}
+{% load i18n static %}
+
+{% block extrahead %}{{ block.super }}
+<script src="https://www.cryptopro.ru/sites/default/files/products/cades/cadesplugin_api.js"
+        onerror="this.onerror=null;this.src='{% static 'approvals/js/cadesplugin_api.js' %}';"></script>
+<style>
+  .sign-wrap { max-width: 720px; }
+
+  .sign-doc-card {
+    border: 1px solid #79aec8;
+    border-radius: 10px;
+    padding: 16px 20px;
+    margin-bottom: 24px;
+    background: rgba(121,174,200,.07);
+  }
+  .sign-doc-card h3 { margin: 0 0 6px; font-size: 16px; font-weight: 700; }
+  .sign-doc-card p  { margin: 3px 0; font-size: 13px; color: var(--body-quiet-color, #aaa); }
+  .sign-doc-card .pill-recheck {
+    display: inline-block; margin-top: 6px;
+    background: #FB8C00; color: #fff;
+    border-radius: 12px; padding: 2px 10px; font-size: 11px; font-weight: 600;
+  }
+
+  .sign-status {
+    padding: 12px 16px; border-radius: 8px;
+    margin-bottom: 16px; font-size: 14px; display: none;
+  }
+  .sign-status.loading { background: rgba(33,150,243,.1);  color: #2196F3; display: block; }
+  .sign-status.error   { background: rgba(229,57,53,.1);   color: #E53935; display: block; }
+  .sign-status.success { background: rgba(76,175,80,.1);   color: #4CAF50; display: block; }
+
+  #cert-section { display: none; }
+  #cert-section h4 { margin: 0 0 10px; font-size: 14px; }
+
+  .cert-list { list-style: none; padding: 0; margin: 0 0 18px; }
+  .cert-item {
+    border: 1px solid var(--hairline-color, #444);
+    border-radius: 8px; padding: 10px 14px;
+    margin-bottom: 8px; cursor: pointer;
+    transition: border-color .15s, background .15s;
+  }
+  .cert-item:hover { border-color: #79aec8; }
+  .cert-item.selected { border-color: #79aec8; background: rgba(121,174,200,.09); }
+  .cert-item label { cursor: pointer; display: flex; align-items: flex-start; gap: 10px; margin: 0; }
+  .cert-item input[type=radio] { margin-top: 3px; accent-color: #79aec8; }
+  .cert-item .cert-cn   { font-weight: 700; font-size: 14px; }
+  .cert-item .cert-meta { font-size: 12px; color: var(--body-quiet-color, #aaa); margin-top: 2px; }
+
+  .sign-actions { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  .btn-sign {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 10px 26px;
+    background: #4CAF50; color: #fff;
+    border: none; border-radius: 7px;
+    font-size: 15px; font-weight: 600; cursor: pointer;
+    transition: background .15s;
+  }
+  .btn-sign:hover:not(:disabled) { background: #388E3C; }
+  .btn-sign:disabled { background: #aaa; cursor: not-allowed; }
+  .btn-sign .spinner {
+    display: none; width: 16px; height: 16px;
+    border: 2px solid rgba(255,255,255,.4); border-top-color: #fff;
+    border-radius: 50%; animation: spin .7s linear infinite;
+  }
+  .btn-sign.busy .spinner { display: inline-block; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  .btn-cancel { color: #79aec8; text-decoration: none; font-size: 14px; }
+  .btn-cancel:hover { text-decoration: underline; }
+
+  .sign-hint {
+    margin-top: 18px; padding: 10px 14px;
+    border: 1px dashed var(--hairline-color, #555);
+    border-radius: 8px; font-size: 12px;
+    color: var(--body-quiet-color, #aaa);
+  }
+  .sign-hint a { color: #79aec8; }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="content-main" class="sign-wrap">
+
+  <div class="sign-doc-card">
+    <p style="font-size:12px;font-weight:600;margin:0 0 6px;">{{ doc_type_label }}</p>
+    <h3>{{ doc_title }}</h3>
+    {% if doc_subtitle %}<p>{{ doc_subtitle }}</p>{% endif %}
+    <p>Отдел: <strong>{{ task.department }}</strong></p>
+    {% if is_ack %}<p>Тип шага: <strong>Ознакомление</strong></p>{% endif %}
+    <p>Маршрут: {{ task.process.route }}</p>
+    <p>Файл для подписи: <strong id="sign-filename">{{ sign_filename }}</strong></p>
+    <p style="margin-top:10px;display:flex;gap:10px;flex-wrap:wrap;">
+      {% if doc_file_url %}
+      <a href="{{ doc_file_url }}" target="_blank"
+         style="color:#5c6bc0;font-weight:600;font-size:13px;text-decoration:none;">📄 Открыть документ</a>
+      {% endif %}
+      {% if doc_admin_url %}
+      <a href="{{ doc_admin_url }}" target="_blank"
+         style="color:#79aec8;font-weight:600;font-size:13px;text-decoration:none;">🗂 Карточка документа</a>
+      {% endif %}
+    </p>
+    {% if task.is_recheck %}<span class="pill-recheck">⟳ Повторная проверка</span>{% endif %}
+  </div>
+
+  <div id="sign-status" class="sign-status loading">⏳ Загружаю список сертификатов…</div>
+
+  <div id="cert-section">
+    <h4>Выберите сертификат ЭЦП:</h4>
+    <ul id="cert-list" class="cert-list"></ul>
+
+    <div class="sign-actions">
+      <button id="sign-btn" class="btn-sign" disabled>
+        <span class="spinner"></span>
+        {% if is_ack %}✍ Подтвердить ознакомление (ЭЦП){% else %}✍ Подписать документ{% endif %}
+      </button>
+      <a href="{{ back_url }}" class="btn-cancel">Отмена</a>
+      <a href="{{ reject_url }}" class="btn-cancel" style="color:#E53935;">Отклонить с замечанием</a>
+    </div>
+  </div>
+
+  <div class="sign-hint">
+    <strong>Как это работает:</strong> КриптоПро подпишет <strong>основной документ (итоговый)</strong>
+    из карточки РКД вашим сертификатом (CAdES-BES, ГОСТ Р 34.10-2012).
+    {% if is_ack %}
+    Подпись сохранится в системе и попадёт в <strong>Лист ознакомления</strong>.
+    {% else %}
+    Подпись сохранится в системе и попадёт в <strong>Лист утверждения</strong>.
+    {% endif %}<br><br>
+    Если браузер запросит PIN-код — введите PIN вашего токена/ключевого контейнера.<br><br>
+    <strong>Если плагин не видит сайт:</strong> в расширении КриптоПро →
+    «Настроить доверенные узлы» → добавьте полный адрес: http://188.120.244.46/admin/ .<br><br>
+    Нет расширения?
+    <a href="https://www.cryptopro.ru/products/cades/plugin" target="_blank">Загрузить КриптоПро Browser Plugin</a>.
+  </div>
+
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  var CONTENT_URL = "{{ content_url }}";
+  var SUBMIT_URL  = "{{ submit_url }}";
+  var CSRF_TOKEN  = "{{ csrf_token }}";
+  var BACK_URL    = "{{ back_url }}";
+
+  var statusEl   = document.getElementById("sign-status");
+  var certSection = document.getElementById("cert-section");
+  var certListEl = document.getElementById("cert-list");
+  var signBtn    = document.getElementById("sign-btn");
+
+  var selectedCertIndex = 0;
+  var documentB64  = null;
+  var signTimeoutId  = null;
+
+  function setStatus(html, type) {
+    statusEl.style.display = "";
+    statusEl.className = "sign-status " + type;
+    statusEl.innerHTML = html;
+  }
+
+  function extractCN(subjectName) {
+    var m = subjectName.match(/(?:^|,\s*)CN=([^,]+)/i);
+    return m ? m[1].trim() : subjectName;
+  }
+
+  fetch(CONTENT_URL, { credentials: "same-origin" })
+    .then(function (r) {
+      return r.json().then(function (data) {
+        if (!r.ok) throw new Error(data.error || ("HTTP " + r.status));
+        return data;
+      });
+    })
+    .then(function (data) {
+      documentB64 = data.content_b64;
+      if (data.filename) {
+        var el = document.getElementById("sign-filename");
+        if (el) el.textContent = data.filename;
+      }
+      initPlugin();
+    })
+    .catch(function (e) {
+      setStatus("❌ Не удалось загрузить основной документ: " + e.message, "error");
+    });
+
+  window.cadesplugin_untrusted_sites_disabled_callback = function (msg) {
+    setStatus(
+      "⚠️ <strong>Сайт не в списке доверенных узлов КриптоПро.</strong><br>" +
+      "Откройте расширение → «Настроить доверенные узлы» → добавьте " +
+      "<code>" + window.location.origin + "</code> (с портом!) и перезагрузите страницу.<br>" +
+      "<small>" + (msg || "") + "</small>",
+      "error"
+    );
+  };
+
+  function initPlugin(attempt) {
+    attempt = attempt || 0;
+    if (typeof cadesplugin === "undefined") {
+      if (attempt < 10) {
+        setTimeout(function () { initPlugin(attempt + 1); }, 300);
+        return;
+      }
+      setStatus(
+        "⚠️ <strong>Не загружен cadesplugin_api.js.</strong><br>" +
+        "Обновите страницу (Ctrl+F5). Проверьте интернет и что расширение КриптоПро включено.",
+        "error"
+      );
+      return;
+    }
+
+    cadesplugin.then(
+      function () { loadCertificates(); },
+      function (e) {
+        var err = (e && e.message) ? e.message : String(e || "неизвестная ошибка");
+        var hint = "";
+        if (/доверенн|untrusted|0xC2110F00/i.test(err)) {
+          hint = "<br><br>Добавьте <code>" + window.location.origin +
+                 "</code> (с портом!) в «Настроить доверенные узлы» расширения КриптоПро.";
+        } else {
+          hint = "<br><br>Убедитесь, что расширение включено: " +
+                 "<a href=\"https://www.cryptopro.ru/products/cades/plugin\" target=\"_blank\">cryptopro.ru</a>";
+        }
+        setStatus("❌ Ошибка инициализации КриптоПро: " + err + hint, "error");
+      }
+    );
+  }
+
+  function loadCertificates() {
+    cadesplugin.async_spawn(function *() {
+      try {
+        var oStore = yield cadesplugin.CreateObjectAsync("CAdESCOM.Store");
+        yield oStore.Open(
+          cadesplugin.CAPICOM_CURRENT_USER_STORE,
+          cadesplugin.CAPICOM_MY_STORE,
+          cadesplugin.CAPICOM_STORE_OPEN_MAXIMUM_ALLOWED
+        );
+
+        var oCerts = yield oStore.Certificates;
+        var count  = yield oCerts.Count;
+
+        if (count === 0) {
+          setStatus(
+            "Сертификаты с закрытым ключом не найдены.<br>" +
+            "Убедитесь, что USB-токен подключён или ключевой контейнер установлен.",
+            "error"
+          );
+          yield oStore.Close();
+          return;
+        }
+
+        var items = [];
+        for (var i = 1; i <= count; i++) {
+          var cert        = yield oCerts.Item(i);
+          var subjectName = yield cert.SubjectName;
+          var validTo     = yield cert.ValidToDate;
+          items.push({ subjectName: subjectName, validTo: validTo, index: i });
+        }
+        yield oStore.Close();
+
+        statusEl.style.display = "none";
+        certSection.style.display = "block";
+        renderCerts(items);
+
+      } catch (e) {
+        setStatus("Ошибка при загрузке сертификатов: " + (e.message || e), "error");
+      }
+    });
+  }
+
+  function renderCerts(items) {
+    certListEl.innerHTML = "";
+    items.forEach(function (item) {
+      var cn    = extractCN(item.subjectName);
+      var until = new Date(item.validTo).toLocaleDateString("ru-RU");
+      var li    = document.createElement("li");
+      li.className = "cert-item";
+      li.innerHTML =
+        "<label>" +
+        "<input type=\"radio\" name=\"cert\">" +
+        "<div>" +
+        "<div class=\"cert-cn\">" + cn + "</div>" +
+        "<div class=\"cert-meta\">Действителен до: " + until + "</div>" +
+        "</div></label>";
+
+      li.addEventListener("click", function () {
+        document.querySelectorAll(".cert-item").forEach(function (el) {
+          el.classList.remove("selected");
+        });
+        li.classList.add("selected");
+        li.querySelector("input[type=radio]").checked = true;
+        selectedCertIndex = item.index;
+        signBtn.disabled = false;
+      });
+
+      certListEl.appendChild(li);
+    });
+
+    if (items.length === 1) {
+      certListEl.querySelector(".cert-item").click();
+    }
+  }
+
+  function clearSignTimeout() {
+    if (signTimeoutId) {
+      clearTimeout(signTimeoutId);
+      signTimeoutId = null;
+    }
+  }
+
+  function formatPluginError(err) {
+    try {
+      return cadesplugin.getLastError(err) || (err && err.message) || String(err);
+    } catch (e) {
+      return (err && err.message) || String(err);
+    }
+  }
+
+  function onSignComplete(err, sig) {
+    clearSignTimeout();
+    signBtn.classList.remove("busy");
+    if (err) {
+      setStatus("❌ Ошибка подписания: " + err, "error");
+      signBtn.disabled = false;
+      return;
+    }
+    submitSignature(sig);
+  }
+
+  signBtn.addEventListener("click", function () {
+    if (!selectedCertIndex || !documentB64) {
+      setStatus("⚠️ Выберите сертификат и дождитесь загрузки данных документа.", "error");
+      return;
+    }
+    signBtn.disabled = true;
+    signBtn.classList.add("busy");
+    setStatus(
+      "⏳ Подписываю документ…<br>" +
+      "Если появился запрос PIN — введите PIN токена (окно может быть за браузером).",
+      "loading"
+    );
+
+    clearSignTimeout();
+    signTimeoutId = setTimeout(function () {
+      signBtn.classList.remove("busy");
+      signBtn.disabled = false;
+      setStatus(
+        "⚠️ Подписание заняло слишком долго.<br>" +
+        "Проверьте, не ждёт ли система PIN-код (окно может быть за браузером). " +
+        "Попробуйте ещё раз.",
+        "error"
+      );
+    }, 60000);
+
+    var certIndex  = selectedCertIndex;
+    var contentB64 = documentB64;
+
+    cadesplugin.async_spawn(function *() {
+      var oStore = null;
+      try {
+        oStore = yield cadesplugin.CreateObjectAsync("CAdESCOM.Store");
+        yield oStore.Open(
+          cadesplugin.CAPICOM_CURRENT_USER_STORE,
+          cadesplugin.CAPICOM_MY_STORE,
+          cadesplugin.CAPICOM_STORE_OPEN_MAXIMUM_ALLOWED
+        );
+
+        var oCerts = yield oStore.Certificates;
+        var oCert  = yield oCerts.Item(certIndex);
+
+        var oSigner = yield cadesplugin.CreateObjectAsync("CAdESCOM.CPSigner");
+        yield oSigner.propset_Certificate(oCert);
+        yield oSigner.propset_CheckCertificate(false);
+
+        var oData = yield cadesplugin.CreateObjectAsync("CAdESCOM.CadesSignedData");
+        yield oData.propset_ContentEncoding(cadesplugin.CADESCOM_BASE64_TO_BINARY);
+        yield oData.propset_Content(contentB64);
+
+        var sSig = yield oData.SignCades(oSigner, cadesplugin.CADESCOM_CADES_BES, true);
+        yield oStore.Close();
+        onSignComplete(null, sSig);
+
+      } catch (e) {
+        if (oStore) {
+          try { yield oStore.Close(); } catch (ignore) {}
+        }
+        onSignComplete(formatPluginError(e), null);
+      }
+    });
+  });
+
+  function submitSignature(sigB64) {
+    clearSignTimeout();
+    signBtn.classList.add("busy");
+    setStatus("⏳ Подпись создана, отправляю на сервер…", "loading");
+
+    var fd = new FormData();
+    fd.append("signature", sigB64);
+    fd.append("csrfmiddlewaretoken", CSRF_TOKEN);
+
+    fetch(SUBMIT_URL, { method: "POST", body: fd, credentials: "same-origin" })
+      .then(function (r) { return r.json(); })
+      .then(function (data) {
+        signBtn.classList.remove("busy");
+        if (data.ok) {
+          setStatus("✅ " + (data.message || "Документ успешно подписан!"), "success");
+          setTimeout(function () { window.location.href = BACK_URL; }, 2200);
+        } else {
+          setStatus("❌ " + (data.error || "Неизвестная ошибка сервера."), "error");
+          signBtn.disabled = false;
+        }
+      })
+      .catch(function (e) {
+        signBtn.classList.remove("busy");
+        setStatus("❌ Ошибка сети: " + e.message, "error");
+        signBtn.disabled = false;
+      });
+  }
+
+})();
+</script>
+{% endblock %}

--- a/templates/admin/approvals/start_approval.html
+++ b/templates/admin/approvals/start_approval.html
@@ -1,0 +1,41 @@
+{% extends "admin/base_site.html" %}
+
+{% block content %}
+<div id="content-main" style="max-width:750px;">
+
+  <div style="border:1px solid var(--hairline-color,#444);border-radius:10px;
+              padding:16px 20px;margin-bottom:20px;">
+    <div style="font-size:13px;font-weight:600;margin-bottom:10px;opacity:.75;">
+      {{ doc_type_label }} — документы для отправки на согласование:
+    </div>
+    <ul style="margin:0;padding-left:18px;">
+      {% for doc in documents %}
+      <li style="margin-bottom:4px;">
+        <strong>{{ doc }}</strong>
+      </li>
+      {% empty %}
+      <li style="color:#E53935;">Документы не выбраны.</li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <p>Выберите маршрут согласования — документ пройдёт по всем его шагам по порядку.</p>
+
+  <form method="post">
+    {% csrf_token %}
+    <input type="hidden" name="doc_type" value="{{ doc_type }}">
+    <input type="hidden" name="ids" value="{{ ids }}">
+    <table>{{ form.as_table }}</table>
+    <div style="display:flex;gap:10px;margin-top:16px;">
+      <input type="submit" value="Запустить согласование" class="default"
+             style="padding:10px 22px;font-size:14px;">
+      <a href="{% url 'admin:approvals_approvalprocess_changelist' %}"
+         style="padding:10px 22px;font-size:14px;border-radius:4px;
+                border:1px solid #79aec8;color:#79aec8;text-decoration:none;">
+        Отмена
+      </a>
+    </div>
+  </form>
+
+</div>
+{% endblock %}

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -1,0 +1,22 @@
+{% extends "admin/base.html" %}
+
+{% block title %}{{ title }} | {{ site_title|default:_('Django site admin') }}{% endblock %}
+
+{% block branding %}
+<h1 id="site-name"><a href="{% url 'admin:index' %}">{{ site_header|default:_('Django administration') }}</a></h1>
+{% endblock %}
+
+{% block nav-global %}
+{% if cabinet_url %}
+<a href="{{ cabinet_url }}"
+   style="display:inline-flex;align-items:center;gap:6px;margin-left:16px;
+          padding:5px 12px;border-radius:16px;background:#417690;color:#fff;
+          text-decoration:none;font-weight:600;font-size:13px;">
+  🔔 Личный кабинет
+  {% if cabinet_total_count %}
+  <span style="background:#E53935;color:#fff;border-radius:10px;
+               padding:1px 7px;font-size:11px;line-height:1.4;">{{ cabinet_total_count }}</span>
+  {% endif %}
+</a>
+{% endif %}
+{% endblock %}

--- a/templates/admin/blog/workassignment/change_form.html
+++ b/templates/admin/blog/workassignment/change_form.html
@@ -179,5 +179,21 @@
       var li = link.closest("li");
       if (li) li.remove();
     });
+
+    // Автозаполнение даты фиксации при смене статуса
+    document.addEventListener("DOMContentLoaded", function () {
+      var statusField = document.getElementById("id_control_status");
+      var dateField   = document.getElementById("id_control_date");
+      if (!statusField || !dateField) return;
+
+      statusField.addEventListener("change", function () {
+        if (!statusField.value) return;
+        var today = new Date();
+        var yyyy  = today.getFullYear();
+        var mm    = String(today.getMonth() + 1).padStart(2, "0");
+        var dd    = String(today.getDate()).padStart(2, "0");
+        dateField.value = dd + "." + mm + "." + yyyy;
+      });
+    });
   </script>
 {% endblock %}

--- a/templates/pdf/acquaintance_sheet_template.html
+++ b/templates/pdf/acquaintance_sheet_template.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8">
-  <title>Лист утверждения — {{ rkd.desig_document }}</title>
+  <title>Лист ознакомления — {{ rkd.desig_document }}</title>
   <style>
     @page {
       size: A4;
@@ -87,7 +87,7 @@
 
   <div class="company">ОБЩЕСТВО С ОГРАНИЧЕННОЙ ОТВЕТСТВЕННОСТЬЮ &quot;СИСТЕМА&quot;</div>
 
-  <h1>Лист утверждения</h1>
+  <h1>Лист ознакомления</h1>
 
   <p class="desig-center">{{ rkd.desig_document|default:"—" }}</p>
 
@@ -110,19 +110,19 @@
       </tr>
     </thead>
     <tbody>
-      {% for sig in signatures %}
+      {% for row in rows %}
       <tr>
-        <td class="num-col">{{ forloop.counter }}</td>
-        <td class="pos-col">{{ sig.role }}</td>
+        <td class="num-col">{{ row.number }}</td>
+        <td class="pos-col">{{ row.position }}</td>
         <td class="name-col">
-          {{ sig.fio }}
-          {% if sig.cert_issuer %}
-            <div class="cert-meta">УЦ: {{ sig.cert_issuer }}</div>
+          {{ row.fio }}
+          {% if row.cert_issuer %}
+            <div class="cert-meta">УЦ: {{ row.cert_issuer }}</div>
           {% endif %}
         </td>
-        <td class="date-col">{{ sig.date|default:"" }}</td>
+        <td class="date-col">{{ row.date|default:"" }}</td>
         <td class="sig-col">
-          {% if sig.cert_cn or sig.cert_issuer %}
+          {% if row.cert_cn or row.cert_issuer %}
             <span class="eds-badge">Подписано ЭЦП</span>
           {% else %}
             &nbsp;
@@ -131,7 +131,7 @@
       </tr>
       {% empty %}
       <tr class="empty-row">
-        <td colspan="5">Подписи не добавлены</td>
+        <td colspan="5">Ознакомления не зафиксированы</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/templates/pdf/approval_sheet_template.html
+++ b/templates/pdf/approval_sheet_template.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8">
+  <title>Лист утверждения — {{ rkd.desig_document }}</title>
+  <style>
+    @page {
+      size: A4;
+      margin: 20mm 20mm 20mm 25mm;
+    }
+    body {
+      font-family: 'DejaVu Sans', 'Arial', sans-serif;
+      font-size: 11px;
+      color: #000;
+    }
+    h1 {
+      text-align: center;
+      font-size: 14px;
+      font-weight: bold;
+      margin: 0 0 6px 0;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+    .subtitle {
+      text-align: center;
+      font-size: 11px;
+      margin-bottom: 18px;
+      color: #333;
+    }
+    .doc-info {
+      margin-bottom: 16px;
+      border: 1px solid #aaa;
+      padding: 8px 12px;
+      background: #f9f9f9;
+    }
+    .doc-info p {
+      margin: 3px 0;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 10px;
+    }
+    th, td {
+      border: 1px solid #555;
+      padding: 6px 8px;
+      vertical-align: middle;
+      text-align: left;
+    }
+    th {
+      background: #e8e8e8;
+      font-weight: bold;
+      font-size: 10px;
+      text-align: center;
+    }
+    td.role-col   { width: 32%; }
+    td.name-col   { width: 28%; }
+    td.sig-col    { width: 24%; text-align: center; }
+    td.date-col   { width: 16%; text-align: center; }
+    .sig-img {
+      max-height: 36px;
+      max-width: 90px;
+    }
+    .no-sig {
+      color: #aaa;
+      font-style: italic;
+      font-size: 10px;
+    }
+    .footer {
+      margin-top: 24px;
+      font-size: 9px;
+      color: #666;
+      border-top: 1px solid #ccc;
+      padding-top: 6px;
+      text-align: right;
+    }
+    .empty-row td {
+      color: #999;
+      font-style: italic;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>Лист утверждения</h1>
+  <p class="subtitle">{{ rkd.desig_document }}{% if rkd.name %} — {{ rkd.name }}{% endif %}</p>
+
+  <div class="doc-info">
+    {% if rkd.post %}
+    <p><strong>Разработка / проект:</strong> {{ rkd.post }}</p>
+    {% endif %}
+    <p><strong>Обозначение документа:</strong> {{ rkd.desig_document|default:"—" }}</p>
+    <p><strong>Наименование:</strong> {{ rkd.name|default:"—" }}</p>
+    {% if rkd.litera %}
+    <p><strong>Литера:</strong> {{ rkd.litera }}</p>
+    {% endif %}
+  </div>
+
+  <table>
+    <thead>
+      <tr>
+        <th class="role-col">Роль</th>
+        <th class="name-col">ФИО</th>
+        <th class="sig-col">Подпись</th>
+        <th class="date-col">Дата</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for sig in signatures %}
+      <tr>
+        <td class="role-col">{{ sig.role }}</td>
+        <td class="name-col">{{ sig.signed_by }}</td>
+        <td class="sig-col">
+          {% if sig.img_b64 %}
+            <img class="sig-img" src="{{ sig.img_b64 }}" alt="подпись">
+          {% else %}
+            <span class="no-sig">нет файла</span>
+          {% endif %}
+        </td>
+        <td class="date-col">{{ sig.date|default:"" }}</td>
+      </tr>
+      {% empty %}
+      <tr class="empty-row">
+        <td colspan="4">Подписи не добавлены</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+
+  <div class="footer">
+    Сгенерировано: {{ generated_at|date:"d.m.Y H:i" }}
+  </div>
+
+</body>
+</html>

--- a/templates/pdf/workflow_sheet_template.html
+++ b/templates/pdf/workflow_sheet_template.html
@@ -2,7 +2,7 @@
 <html lang="ru">
 <head>
   <meta charset="UTF-8">
-  <title>Лист утверждения — {{ rkd.desig_document }}</title>
+  <title>{{ sheet_title }} — {{ center_line }}</title>
   <style>
     @page {
       size: A4;
@@ -87,16 +87,14 @@
 
   <div class="company">ОБЩЕСТВО С ОГРАНИЧЕННОЙ ОТВЕТСТВЕННОСТЬЮ &quot;СИСТЕМА&quot;</div>
 
-  <h1>Лист утверждения</h1>
+  <h1>{{ sheet_title }}</h1>
 
-  <p class="desig-center">{{ rkd.desig_document|default:"—" }}</p>
+  <p class="desig-center">{{ center_line|default:"—" }}</p>
 
   <div class="doc-info">
-    {% if rkd.post %}
-    <p><strong>Разработка (модификация):</strong> {{ rkd.post }}</p>
-    {% endif %}
-    <p><strong>Обозначение документа:</strong> {{ rkd.desig_document|default:"—" }}</p>
-    <p><strong>Наименование:</strong> {{ rkd.name|default:"—" }}</p>
+    {% for label, value in doc_info_lines %}
+    <p><strong>{{ label }}:</strong> {{ value|default:"—" }}</p>
+    {% endfor %}
   </div>
 
   <table>
@@ -110,19 +108,19 @@
       </tr>
     </thead>
     <tbody>
-      {% for sig in signatures %}
+      {% for row in rows %}
       <tr>
-        <td class="num-col">{{ forloop.counter }}</td>
-        <td class="pos-col">{{ sig.role }}</td>
+        <td class="num-col">{{ row.number }}</td>
+        <td class="pos-col">{{ row.position }}</td>
         <td class="name-col">
-          {{ sig.fio }}
-          {% if sig.cert_issuer %}
-            <div class="cert-meta">УЦ: {{ sig.cert_issuer }}</div>
+          {{ row.fio }}
+          {% if row.cert_issuer %}
+            <div class="cert-meta">УЦ: {{ row.cert_issuer }}</div>
           {% endif %}
         </td>
-        <td class="date-col">{{ sig.date|default:"" }}</td>
+        <td class="date-col">{{ row.date|default:"" }}</td>
         <td class="sig-col">
-          {% if sig.cert_cn or sig.cert_issuer %}
+          {% if row.cert_cn or row.cert_issuer %}
             <span class="eds-badge">Подписано ЭЦП</span>
           {% else %}
             &nbsp;
@@ -131,7 +129,7 @@
       </tr>
       {% empty %}
       <tr class="empty-row">
-        <td colspan="5">Подписи не добавлены</td>
+        <td colspan="5">Записи не добавлены</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
Added approvals app: admin personal cabinet with tasks and notifications; CAdES signing of uploaded document files; auto-generated approval (LU) and acquaintance (LO) PDF sheets; support for Universal RKD, QMS documents, standalone shared documents, and administrative orders; approval routes and departments; LU/LO column in admin changelists; CryptoPro sign page and cabinet badge in admin header. 
