### PR TITLE
Update-1.0039-from-23-06-2026-(Approvals: split approval/acquaintance routes, broadcast targets; extended personal cabinet)

### DIFF
--- a/approvals/admin.py
+++ b/approvals/admin.py
@@ -27,12 +27,13 @@ from .models import (
     DepartmentMember,
     Vacation,
     ApprovalRoute,
+    AcknowledgmentRoute,
     ApprovalRouteStep,
     ApprovalProcess,
     ApprovalTask,
     Notification,
 )
-from .services import ApprovalEngine
+from .services import ApprovalEngine, resolve_assignee, _resolve_step_users
 
 
 def is_approval_admin(user):
@@ -119,8 +120,11 @@ class DepartmentMemberInline(admin.TabularInline):
     model = DepartmentMember
     extra = 1
     autocomplete_fields = ("user",)
-    verbose_name = "Сотрудник отдела"
-    verbose_name_plural = "Сотрудники (главный + заместители по очереди)"
+    verbose_name = "Сотрудник роли"
+    verbose_name_plural = "Сотрудники роли (главный + заместители по очереди)"
+
+    class Media:
+        js = ("approvals/js/inline_order.js",)
 
 
 @admin.register(Department)
@@ -141,17 +145,115 @@ class DepartmentAdmin(_AdminOnlyMixin, admin.ModelAdmin):
 
 @admin.register(Vacation)
 class VacationAdmin(_AdminOnlyMixin, admin.ModelAdmin):
-    list_display = ("user", "start_date", "end_date", "reason")
-    list_filter = ("start_date", "end_date")
+    list_display = (
+        "user", "absence_type", "start_date", "end_date",
+        "days_display", "reason",
+    )
+    list_filter = ("absence_type", "start_date", "end_date")
     search_fields = ("user__username", "user__last_name", "reason")
     autocomplete_fields = ("user",)
+    date_hierarchy = "start_date"
+    fields = ("user", "absence_type", ("start_date", "end_date"), "reason")
+
+    @admin.display(description="Дней", ordering="start_date")
+    def days_display(self, obj):
+        return obj.days if obj.days is not None else "—"
+
+
+def _route_steps_preview(obj):
+    steps = obj.steps.select_related("department", "org_department").order_by("order")
+    if not steps:
+        return "—"
+    lines = []
+    for s in steps:
+        if s.target_type == ApprovalRouteStep.TARGET_ALL:
+            lines.append(format_html("<div><b>{}.</b> {}</div>", s.order, s.target_label))
+            continue
+
+        people = [u for u in _resolve_step_users(s) if u]
+        names = [u.get_full_name() or u.username for u in people]
+        if names:
+            who = ", ".join(names[:8])
+            if len(names) > 8:
+                who += f" и ещё {len(names) - 8}"
+        else:
+            who = "не назначен"
+        lines.append(format_html("<div><b>{}.</b> {} — {}</div>", s.order, s.target_label, who))
+    return format_html_join("", "{}", ((line,) for line in lines))
+
+
+def _collect_responsible_items(user, limit_per_model=200):
+    """Все объекты во всех моделях, где пользователь — «Текущий ответственный»."""
+    from django.apps import apps
+    from django.contrib.auth import get_user_model
+    from django.core.exceptions import FieldDoesNotExist
+    from django.db.models import ForeignKey
+    from django.urls import NoReverseMatch
+
+    user_model = get_user_model()
+    # Рабочие задания и подзадачи показываются в отдельных вкладках ЛК.
+    excluded_labels = {"blog.workassignment", "blog.workassignmentsubtask"}
+    items = []
+    for model in apps.get_models():
+        if model._meta.label_lower in excluded_labels:
+            continue
+        try:
+            field = model._meta.get_field("current_responsible")
+        except FieldDoesNotExist:
+            continue
+        if not isinstance(field, ForeignKey):
+            continue
+        if field.remote_field.model is not user_model:
+            continue
+        try:
+            objs = list(
+                model.objects.filter(current_responsible=user).order_by("-pk")[:limit_per_model]
+            )
+        except Exception:
+            # Пропускаем модель, если её таблица недоступна / рассинхронизирована со схемой.
+            continue
+        for obj in objs:
+            try:
+                url = reverse(
+                    f"admin:{model._meta.app_label}_{model._meta.model_name}_change",
+                    args=[obj.pk],
+                )
+            except NoReverseMatch:
+                url = ""
+            items.append({
+                "title": str(obj),
+                "model_label": str(model._meta.verbose_name),
+                "admin_url": url,
+            })
+    items.sort(key=lambda x: (x["model_label"], x["title"]))
+    return items
 
 
 class ApprovalRouteStepInline(admin.TabularInline):
+    """Шаги маршрута согласования — только по роли, последовательно."""
     model = ApprovalRouteStep
     extra = 1
+    fields = ("order", "department")
     verbose_name = "Шаг маршрута"
     verbose_name_plural = "Шаги маршрута (по порядку)"
+
+    class Media:
+        js = ("approvals/js/inline_order.js",)
+
+
+class AckRouteStepInline(admin.StackedInline):
+    """Шаги маршрута ознакомления — по роли, отделу, всем или руководителям."""
+    model = ApprovalRouteStep
+    extra = 1
+    fields = ("order", "target_type", "department", "org_department")
+    verbose_name = "Шаг маршрута"
+    verbose_name_plural = "Шаги маршрута (по порядку)"
+
+    class Media:
+        js = (
+            "approvals/js/inline_order.js",
+            "approvals/js/ack_step_target.js",
+        )
 
 
 @admin.register(ApprovalRoute)
@@ -159,14 +261,69 @@ class ApprovalRouteAdmin(_AdminOnlyMixin, admin.ModelAdmin):
     list_display = ("name", "steps_preview", "is_active")
     list_filter = ("is_active",)
     search_fields = ("name", "description")
+    fields = ("name", "description", "is_active")
     inlines = [ApprovalRouteStepInline]
 
-    @admin.display(description="Маршрут")
+    def get_queryset(self, request):
+        return super().get_queryset(request).filter(kind=ApprovalRoute.KIND_APPROVAL)
+
+    def save_model(self, request, obj, form, change):
+        obj.kind = ApprovalRoute.KIND_APPROVAL
+        super().save_model(request, obj, form, change)
+
+    def save_formset(self, request, form, formset, change):
+        if formset.model is ApprovalRouteStep:
+            instances = formset.save(commit=False)
+            for obj in formset.deleted_objects:
+                obj.delete()
+            for obj in instances:
+                obj.action_type = ApprovalRouteStep.ACTION_SIGN
+                obj.target_type = ApprovalRouteStep.TARGET_ROLE
+                obj.org_department = None
+                obj.save()
+            formset.save_m2m()
+        else:
+            super().save_formset(request, form, formset, change)
+
+    @admin.display(description="Маршрут (роли → ответственные)")
     def steps_preview(self, obj):
-        steps = obj.steps.select_related("department").order_by("order")
-        if not steps:
-            return "—"
-        return " → ".join(str(s.department) for s in steps)
+        return _route_steps_preview(obj)
+
+
+@admin.register(AcknowledgmentRoute)
+class AcknowledgmentRouteAdmin(_AdminOnlyMixin, admin.ModelAdmin):
+    list_display = ("name", "steps_preview", "is_active")
+    list_filter = ("is_active",)
+    search_fields = ("name", "description")
+    fields = ("name", "description", "is_active")
+    inlines = [AckRouteStepInline]
+
+    def get_queryset(self, request):
+        return super().get_queryset(request).filter(kind=ApprovalRoute.KIND_ACK)
+
+    def save_model(self, request, obj, form, change):
+        obj.kind = ApprovalRoute.KIND_ACK
+        super().save_model(request, obj, form, change)
+
+    def save_formset(self, request, form, formset, change):
+        if formset.model is ApprovalRouteStep:
+            instances = formset.save(commit=False)
+            for obj in formset.deleted_objects:
+                obj.delete()
+            for obj in instances:
+                obj.action_type = ApprovalRouteStep.ACTION_ACK
+                if obj.target_type != ApprovalRouteStep.TARGET_ROLE:
+                    obj.department = None
+                if obj.target_type != ApprovalRouteStep.TARGET_DEPARTMENT:
+                    obj.org_department = None
+                obj.save()
+            formset.save_m2m()
+        else:
+            super().save_formset(request, form, formset, change)
+
+    @admin.display(description="Маршрут (адресаты ознакомления)")
+    def steps_preview(self, obj):
+        return _route_steps_preview(obj)
 
 
 class ApprovalTaskInline(admin.TabularInline):
@@ -333,7 +490,7 @@ class ApprovalProcessAdmin(admin.ModelAdmin):
         return format_html(
             "<table style='width:100%;border-collapse:collapse;margin-top:4px;'>"
             "<thead><tr style='background:#f0f0f0;'>"
-            "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Отдел</th>"
+            "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Роль</th>"
             "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Подписант</th>"
             "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Дата</th>"
             "<th style='padding:8px;border:1px solid #ccc;text-align:left;'>Сертификат</th>"
@@ -447,6 +604,12 @@ class ApprovalProcessAdmin(admin.ModelAdmin):
         )
 
     def start_view(self, request):
+        mode = request.GET.get("mode") or request.POST.get("mode") or "approval"
+        if mode not in ("approval", "ack"):
+            mode = "approval"
+        kind = ApprovalRoute.KIND_ACK if mode == "ack" else ApprovalRoute.KIND_APPROVAL
+        action_label = "ознакомление" if mode == "ack" else "согласование"
+
         doc_type = (
             request.GET.get("doc_type")
             or request.POST.get("doc_type")
@@ -468,32 +631,41 @@ class ApprovalProcessAdmin(admin.ModelAdmin):
         documents = resolve_documents(doc_type, ids)
 
         if request.method == "POST":
-            form = StartApprovalForm(request.POST)
+            form = StartApprovalForm(request.POST, kind=kind)
             if form.is_valid():
                 route = form.cleaned_data["route"]
+                comment = form.cleaned_data.get("comment", "")
                 started, errors = 0, []
                 for document in documents:
                     try:
-                        ApprovalEngine.start(document, route, request.user)
+                        ApprovalEngine.start(document, route, request.user, comment=comment)
                         started += 1
                     except ValueError as e:
                         errors.append(f"{document}: {e}")
                 if started:
-                    self.message_user(request, f"Запущено согласований: {started}.")
+                    self.message_user(request, f"Запущено ({action_label}): {started}.")
                 for err in errors:
                     self.message_user(request, err, level=messages.ERROR)
                 return redirect("admin:approvals_approvalprocess_changelist")
         else:
-            form = StartApprovalForm()
+            form = StartApprovalForm(kind=kind)
+
+        routes_info = [
+            {"route": r, "preview": _route_steps_preview(r)}
+            for r in ApprovalRoute.objects.filter(is_active=True, kind=kind).order_by("name")
+        ]
 
         context = {
             **self.admin_site.each_context(request),
-            "title": f"Отправить на согласование — {cfg.label}",
+            "title": f"Отправить на {action_label} — {cfg.label}",
             "form": form,
             "documents": documents,
             "doc_type": doc_type,
             "doc_type_label": cfg.label,
             "ids": raw_ids,
+            "mode": mode,
+            "mode_label": action_label,
+            "routes_info": routes_info,
             "opts": self.model._meta,
         }
         return render(request, "admin/approvals/start_approval.html", context)
@@ -686,7 +858,7 @@ class ApprovalTaskAdmin(admin.ModelAdmin):
     def cabinet_view(self, request):
         from django.db.models import Count
 
-        from blog.models import WorkAssignment
+        from blog.models import WorkAssignment, WorkAssignmentSubtask
 
         user = request.user
         pending = list(
@@ -724,6 +896,26 @@ class ApprovalTaskAdmin(admin.ModelAdmin):
             Q(control_status__isnull=True) | Q(control_status="in_progress")
         ).count()
 
+        my_subtasks = list(
+            WorkAssignmentSubtask.objects
+            .filter(executor=user)
+            .filter(Q(control_status__isnull=True) | Q(control_status="in_progress"))
+            .select_related("work_assignment", "work_assignment__post")
+            .order_by("work_assignment_id", "subtask_number", "pk")
+        )
+        subtask_groups, _cur = [], None
+        for st in my_subtasks:
+            if _cur is None or _cur["wa_id"] != st.work_assignment_id:
+                _cur = {
+                    "wa_id": st.work_assignment_id,
+                    "wa": st.work_assignment,
+                    "subtasks": [],
+                }
+                subtask_groups.append(_cur)
+            _cur["subtasks"].append(st)
+
+        assigned_items = _collect_responsible_items(user)
+
         notifications = list(Notification.objects.filter(recipient=user)[:50])
         unread_count = sum(1 for n in notifications if not n.is_read)
 
@@ -750,6 +942,9 @@ class ApprovalTaskAdmin(admin.ModelAdmin):
             "ack_tasks": ack_tasks,
             "fix_tasks": fix_tasks,
             "my_work": my_work,
+            "my_subtasks": my_subtasks,
+            "subtask_groups": subtask_groups,
+            "assigned_items": assigned_items,
             "issued_work": issued_work,
             "issued_work_active": issued_work_active,
             "my_docs": my_docs,
@@ -812,7 +1007,7 @@ class ApprovalTaskAdmin(admin.ModelAdmin):
             **self.admin_site.each_context(request),
             "title": "Отправить на доработку",
             "message": f"Отправить исправленный документ «{task_doc_context(task)['title']}» "
-                       f"на повторную проверку в отдел «{task.department}»?",
+                       f"на повторную проверку в роль «{task.department}»?",
             "action_url": request.path,
             "back_url": self._back_url(),
             "opts": self.model._meta,

--- a/approvals/admin_forms.py
+++ b/approvals/admin_forms.py
@@ -5,10 +5,29 @@ from .models import ApprovalRoute
 
 class StartApprovalForm(forms.Form):
     route = forms.ModelChoiceField(
-        queryset=ApprovalRoute.objects.filter(is_active=True),
-        label="Маршрут согласования",
+        queryset=ApprovalRoute.objects.none(),
+        label="Маршрут",
         empty_label="— выберите маршрут —",
     )
+    comment = forms.CharField(
+        label="Сопроводительный комментарий",
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 3, "cols": 60}),
+        help_text="Необязательно. Будет показан в уведомлении адресатам.",
+    )
+
+    def __init__(self, *args, kind=ApprovalRoute.KIND_APPROVAL, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.kind = kind
+        self.fields["route"].queryset = ApprovalRoute.objects.filter(
+            is_active=True, kind=kind,
+        )
+        if kind == ApprovalRoute.KIND_ACK:
+            self.fields["route"].label = "Маршрут ознакомления"
+            self.fields["route"].empty_label = "— выберите маршрут ознакомления —"
+        else:
+            self.fields["route"].label = "Маршрут согласования"
+            self.fields["route"].empty_label = "— выберите маршрут согласования —"
 
 
 class RejectTaskForm(forms.Form):

--- a/approvals/apps.py
+++ b/approvals/apps.py
@@ -10,11 +10,8 @@ GROUP_EMPLOYEE = "Согласование: Сотрудник"
 def _ensure_departments(sender, **kwargs):
     from .models import Department, SIGNATURE_ROLE_CHOICES
 
-    for role_key, role_label in SIGNATURE_ROLE_CHOICES:
-        Department.objects.get_or_create(
-            name=role_label,
-            defaults={"signature_role": role_key},
-        )
+    for _role_key, role_label in SIGNATURE_ROLE_CHOICES:
+        Department.objects.get_or_create(name=role_label)
 
 
 def _ensure_groups(sender, **kwargs):

--- a/approvals/document_types.py
+++ b/approvals/document_types.py
@@ -269,9 +269,14 @@ def task_doc_context(task) -> dict:
     }
 
 
-def role_label_for_department(department) -> str:
-    if not department:
-        return "—"
-    if department.signature_role:
-        return department.get_signature_role_display()
-    return str(department)
+def signer_department_label(user) -> str:
+    """Отдел подписанта берём из его профиля (EmployeeProfile.org_department).
+
+    В ЛУ/ЛО пишем именно отдел текущего пользователя, который подписывает,
+    а не роль из маршрута.
+    """
+    if not user:
+        return ""
+    profile = getattr(user, "profile", None)
+    department = getattr(profile, "org_department", None)
+    return str(department) if department else ""

--- a/approvals/models.py
+++ b/approvals/models.py
@@ -23,20 +23,13 @@ SIGNATURE_ROLE_CHOICES = [
 
 
 class Department(models.Model):
-    name = models.CharField("Название отдела", max_length=150, unique=True)
+    name = models.CharField("Название роли", max_length=150, unique=True)
     code = models.CharField("Код", max_length=20, blank=True)
-    signature_role = models.CharField(
-        "Роль в листе утверждения",
-        max_length=20,
-        choices=SIGNATURE_ROLE_CHOICES,
-        blank=True,
-        help_text="Под какой ролью подпись этого отдела попадёт в лист утверждения РКД.",
-    )
-    is_active = models.BooleanField("Активен", default=True)
+    is_active = models.BooleanField("Активна", default=True)
 
     class Meta:
-        verbose_name = "Отдел"
-        verbose_name_plural = "Отделы"
+        verbose_name = "Роль"
+        verbose_name_plural = "Роли"
         ordering = ("name",)
 
     def __str__(self):
@@ -46,7 +39,7 @@ class Department(models.Model):
 class DepartmentMember(models.Model):
     department = models.ForeignKey(
         Department, on_delete=models.CASCADE,
-        related_name="members", verbose_name="Отдел",
+        related_name="members", verbose_name="Роль",
     )
     user = models.ForeignKey(
         User, on_delete=models.CASCADE,
@@ -59,24 +52,49 @@ class DepartmentMember(models.Model):
     )
 
     class Meta:
-        verbose_name = "Сотрудник отдела"
-        verbose_name_plural = "Сотрудники отделов"
+        verbose_name = "Сотрудник роли"
+        verbose_name_plural = "Сотрудники ролей"
         unique_together = ("department", "user")
         ordering = ("department", "-is_main", "order")
 
     def __str__(self):
-        role = "главный" if self.is_main else f"зам. №{self.order}"
-        return f"{self.user} — {self.department} ({role})"
+        member = "главный" if self.is_main else f"зам. №{self.order}"
+        return f"{self.user} — {self.department} ({member})"
 
 
 class Vacation(models.Model):
+    TYPE_VACATION = "vacation"
+    TYPE_SICK = "sick"
+    TYPE_UNPAID = "unpaid"
+    TYPE_BUSINESS_TRIP = "trip"
+    TYPE_DAY_OFF = "day_off"
+    TYPE_STUDY = "study"
+    TYPE_OTHER = "other"
+
+    TYPE_CHOICES = [
+        (TYPE_VACATION, "Отпуск (ежегодный)"),
+        (TYPE_UNPAID, "Отпуск без сохранения (БС)"),
+        (TYPE_SICK, "Больничный"),
+        (TYPE_BUSINESS_TRIP, "Командировка"),
+        (TYPE_DAY_OFF, "Отгул"),
+        (TYPE_STUDY, "Учебный отпуск"),
+        (TYPE_OTHER, "Другое"),
+    ]
+
     user = models.ForeignKey(
         User, on_delete=models.CASCADE,
         related_name="vacations", verbose_name="Сотрудник",
     )
+    absence_type = models.CharField(
+        "Тип отсутствия", max_length=20,
+        choices=TYPE_CHOICES, default=TYPE_VACATION,
+    )
     start_date = models.DateField("С")
     end_date = models.DateField("По")
-    reason = models.CharField("Причина", max_length=255, blank=True)
+    reason = models.CharField(
+        "Причина / комментарий", max_length=255, blank=True,
+        help_text="Обязательно для типа «Другое». Для остальных типов — по желанию.",
+    )
 
     class Meta:
         verbose_name = "Отпуск / отсутствие"
@@ -84,17 +102,46 @@ class Vacation(models.Model):
         ordering = ("-start_date",)
 
     def __str__(self):
-        return f"{self.user}: {self.start_date:%d.%m.%Y}–{self.end_date:%d.%m.%Y}"
+        return (
+            f"{self.user}: {self.get_absence_type_display()} "
+            f"{self.start_date:%d.%m.%Y}–{self.end_date:%d.%m.%Y}"
+        )
+
+    @property
+    def days(self):
+        if self.start_date and self.end_date:
+            return (self.end_date - self.start_date).days + 1
+        return None
+
+    def is_active_on(self, on_date):
+        if not (self.start_date and self.end_date):
+            return False
+        return self.start_date <= on_date <= self.end_date
 
     def clean(self):
         super().clean()
         if self.start_date and self.end_date and self.end_date < self.start_date:
             raise ValidationError({"end_date": "Дата «По» не может быть раньше «С»."})
+        if self.absence_type == self.TYPE_OTHER and not (self.reason or "").strip():
+            raise ValidationError({
+                "reason": "Для типа «Другое» укажите причину отсутствия.",
+            })
 
 
 class ApprovalRoute(models.Model):
+    KIND_APPROVAL = "approval"
+    KIND_ACK = "acknowledgment"
+    KIND_CHOICES = [
+        (KIND_APPROVAL, "Согласование"),
+        (KIND_ACK, "Ознакомление"),
+    ]
+
     name = models.CharField("Название маршрута", max_length=255, unique=True)
     description = models.CharField("Описание", max_length=500, blank=True)
+    kind = models.CharField(
+        "Тип маршрута", max_length=20,
+        choices=KIND_CHOICES, default=KIND_APPROVAL,
+    )
     is_active = models.BooleanField("Активен", default=True)
 
     class Meta:
@@ -106,6 +153,15 @@ class ApprovalRoute(models.Model):
         return self.name
 
 
+class AcknowledgmentRoute(ApprovalRoute):
+    """Прокси-модель для маршрутов ознакомления — отдельный раздел в админке."""
+
+    class Meta:
+        proxy = True
+        verbose_name = "Маршрут ознакомления"
+        verbose_name_plural = "Маршруты ознакомления"
+
+
 class ApprovalRouteStep(models.Model):
     ACTION_ACK = "acknowledge"
     ACTION_SIGN = "sign"
@@ -114,14 +170,39 @@ class ApprovalRouteStep(models.Model):
         (ACTION_SIGN, "Согласование / Подпись"),
     ]
 
+    TARGET_ROLE = "role"
+    TARGET_DEPARTMENT = "department"
+    TARGET_ALL = "all"
+    TARGET_HEADS = "heads"
+    TARGET_CHOICES = [
+        (TARGET_ROLE, "По роли"),
+        (TARGET_DEPARTMENT, "Весь отдел"),
+        (TARGET_ALL, "Все сотрудники"),
+        (TARGET_HEADS, "Все руководители отделов"),
+    ]
+
     route = models.ForeignKey(
         ApprovalRoute, on_delete=models.CASCADE,
         related_name="steps", verbose_name="Маршрут",
     )
     order = models.PositiveSmallIntegerField("Порядок", default=1)
+    target_type = models.CharField(
+        "Кому", max_length=12,
+        choices=TARGET_CHOICES, default=TARGET_ROLE,
+        help_text="По роли — один ответственный по очереди; "
+                  "остальные варианты рассылают всем разом (для ознакомления).",
+    )
     department = models.ForeignKey(
         Department, on_delete=models.CASCADE,
-        related_name="route_steps", verbose_name="Отдел",
+        related_name="route_steps", verbose_name="Роль",
+        null=True, blank=True,
+    )
+    org_department = models.ForeignKey(
+        "shared_repository.Department",
+        on_delete=models.CASCADE,
+        related_name="route_steps",
+        verbose_name="Отдел",
+        null=True, blank=True,
     )
     action_type = models.CharField(
         "Тип действия", max_length=12,
@@ -135,7 +216,24 @@ class ApprovalRouteStep(models.Model):
         ordering = ("route", "order")
 
     def __str__(self):
-        return f"{self.order}. {self.department} ({self.get_action_type_display()})"
+        return f"{self.order}. {self.target_label}"
+
+    @property
+    def target_label(self):
+        if self.target_type == self.TARGET_ALL:
+            return "Все сотрудники"
+        if self.target_type == self.TARGET_HEADS:
+            return "Все руководители отделов"
+        if self.target_type == self.TARGET_DEPARTMENT:
+            return f"Отдел «{self.org_department}»" if self.org_department_id else "Отдел (не указан)"
+        return f"Роль «{self.department}»" if self.department_id else "Роль (не указана)"
+
+    def clean(self):
+        super().clean()
+        if self.target_type == self.TARGET_ROLE and not self.department_id:
+            raise ValidationError({"department": "Выберите роль для этого шага."})
+        if self.target_type == self.TARGET_DEPARTMENT and not self.org_department_id:
+            raise ValidationError({"org_department": "Выберите отдел для этого шага."})
 
 
 class ApprovalProcess(models.Model):
@@ -179,8 +277,8 @@ class ApprovalProcess(models.Model):
     finished_at = models.DateTimeField("Завершён", null=True, blank=True)
 
     class Meta:
-        verbose_name = "Согласование документа"
-        verbose_name_plural = "Согласования документов"
+        verbose_name = "Согласование/Ознакомление с документом"
+        verbose_name_plural = "Согласования/Ознакомления с документами"
         ordering = ("-created_at",)
 
     def __str__(self):
@@ -224,7 +322,7 @@ class ApprovalTask(models.Model):
     )
     department = models.ForeignKey(
         Department, on_delete=models.SET_NULL, null=True, blank=True,
-        related_name="tasks", verbose_name="Отдел",
+        related_name="tasks", verbose_name="Роль",
     )
     kind = models.CharField(
         "Тип задачи", max_length=10,
@@ -269,6 +367,14 @@ class ApprovalTask(models.Model):
 
     def __str__(self):
         return f"{self.get_kind_display()} — {self.process.get_document() or '—'}"
+
+    @property
+    def target_label(self):
+        if self.department_id:
+            return str(self.department)
+        if self.step_id:
+            return self.step.target_label
+        return "—"
 
     @property
     def is_active(self):
@@ -343,9 +449,9 @@ class ApprovalSheetRecord(models.Model):
     document = GenericForeignKey("content_type", "object_id")
     department = models.ForeignKey(
         Department, on_delete=models.SET_NULL, null=True, blank=True,
-        verbose_name="Отдел",
+        verbose_name="Роль",
     )
-    position = models.CharField("Должность", max_length=150, blank=True)
+    position = models.CharField("Отдел", max_length=150, blank=True)
     role_label = models.CharField("Роль", max_length=150, blank=True)
     signed_by = models.ForeignKey(
         User, on_delete=models.SET_NULL, null=True, blank=True,

--- a/approvals/services.py
+++ b/approvals/services.py
@@ -1,3 +1,5 @@
+from django.contrib.auth import get_user_model
+
 from django.contrib.contenttypes.models import ContentType
 
 from django.db import transaction
@@ -14,7 +16,7 @@ from .document_types import (
 
     get_document_from_process,
 
-    role_label_for_department,
+    signer_department_label,
 
 )
 
@@ -57,6 +59,27 @@ def notify(recipient, title, *, text="", url="", kind=Notification.KIND_INFO):
 def _cabinet_url():
 
     return reverse("admin:approvals_cabinet")
+
+
+
+
+def _rkd_role_for_department(department):
+    """Подбираем код роли для подписи РКД (UniversalRKDSignature.role).
+
+    Роль РКД нужна только как ключ строки подписи в ГОСТ-листе РКД.
+    Берём из совпадения названия роли (Department.name) со справочником ролей;
+    если совпадения нет — используем код/усечённое имя роли, чтобы строки
+    разных ролей не перезаписывали друг друга.
+    """
+    from .models import SIGNATURE_ROLE_CHOICES
+
+    if not department:
+        return "agreed"
+    key_by_label = {label: key for key, label in SIGNATURE_ROLE_CHOICES}
+    name = (department.name or "").strip()
+    if name in key_by_label:
+        return key_by_label[name]
+    return (department.code or name or "agreed")[:20]
 
 
 
@@ -109,6 +132,56 @@ def resolve_assignee(department, on_date=None):
 
 
 
+def _step_target_label(step):
+    """Текстовое описание адресата шага для уведомлений/журнала."""
+    from .models import ApprovalRouteStep
+
+    if step.target_type == ApprovalRouteStep.TARGET_ALL:
+        return "все сотрудники"
+    if step.target_type == ApprovalRouteStep.TARGET_HEADS:
+        return "руководители отделов"
+    if step.target_type == ApprovalRouteStep.TARGET_DEPARTMENT:
+        return f"отдел «{step.org_department}»" if step.org_department_id else "отдел (не указан)"
+    return f"роль «{step.department}»" if step.department_id else "роль (не указана)"
+
+
+def _resolve_step_users(step, on_date=None):
+    """Список пользователей-адресатов шага.
+
+    - По роли: один ответственный с учётом отпусков (как раньше).
+    - Весь отдел / Все / Руководители: рассылка всем сразу (для ознакомления).
+    """
+    from .models import ApprovalRouteStep
+
+    on_date = on_date or timezone.localdate()
+    User = get_user_model()
+
+    if step.target_type == ApprovalRouteStep.TARGET_ALL:
+        return list(User.objects.filter(is_active=True).order_by("last_name", "username"))
+
+    if step.target_type == ApprovalRouteStep.TARGET_HEADS:
+        return list(
+            User.objects.filter(is_active=True, profile__is_head=True)
+            .order_by("last_name", "username")
+        )
+
+    if step.target_type == ApprovalRouteStep.TARGET_DEPARTMENT:
+        if not step.org_department_id:
+            return []
+        return list(
+            User.objects.filter(is_active=True, profile__org_department_id=step.org_department_id)
+            .order_by("last_name", "username")
+        )
+
+    # TARGET_ROLE
+    if not step.department_id:
+        return []
+    assignee = resolve_assignee(step.department, on_date)
+    return [assignee] if assignee else []
+
+
+
+
 
 def _document_label(document) -> str:
 
@@ -128,7 +201,7 @@ class ApprovalEngine:
 
     @transaction.atomic
 
-    def start(document, route, user):
+    def start(document, route, user, comment=""):
 
         cfg = get_config_for_document(document)
 
@@ -158,19 +231,19 @@ class ApprovalEngine:
 
 
 
-        empty_depts = []
+        empty_targets = []
 
-        for step in route.steps.select_related("department").order_by("order"):
+        for step in route.steps.order_by("order"):
 
-            if not DepartmentMember.objects.filter(department=step.department).exists():
+            if not _resolve_step_users(step):
 
-                empty_depts.append(str(step.department))
+                empty_targets.append(step.target_label)
 
-        if empty_depts:
+        if empty_targets:
 
             raise ValueError(
 
-                f"В отделах нет сотрудников, задача некому назначить: {', '.join(empty_depts)}."
+                f"Для шагов маршрута не найдено адресатов: {', '.join(empty_targets)}."
 
             )
 
@@ -202,7 +275,7 @@ class ApprovalEngine:
 
         process = ApprovalProcess.objects.create(**process_kwargs)
 
-        ApprovalEngine._create_review_task(process, first_step)
+        ApprovalEngine._create_step_tasks(process, first_step, launch_comment=comment)
 
 
 
@@ -232,63 +305,63 @@ class ApprovalEngine:
 
     @staticmethod
 
-    def _create_review_task(process, step, *, is_recheck=False, parent=None):
+    def _create_step_tasks(process, step, *, is_recheck=False, parent=None, launch_comment=""):
+        """Создаёт задачи для шага маршрута.
 
-        assignee = resolve_assignee(step.department)
-
+        Для адресата «по роли» — одна задача (с учётом отпусков).
+        Для «весь отдел / все / руководители» — задачи всем сразу (параллельно).
+        """
         process.current_order = step.order
-
         process.save(update_fields=["current_order"])
 
-
-
         document = get_document_from_process(process)
-
         cfg = get_config_for_document(document)
-
         doc_label = _document_label(document)
 
-
-
-        task = ApprovalTask.objects.create(
-
-            process=process,
-
-            step=step,
-
-            department=step.department,
-
-            kind=ApprovalTask.KIND_REVIEW,
-
-            assigned_to=assignee,
-
-            is_recheck=is_recheck,
-
-            parent=parent,
-
-        )
-
         is_sign = step.action_type == step.ACTION_SIGN
-
         prefix = "Повторно: " if is_recheck else ""
-
         action = "на согласование / подпись" if is_sign else "на ознакомление"
+        target_label = _step_target_label(step)
+        note_text = f"«{doc_label}» — {target_label}."
+        if launch_comment.strip():
+            note_text += f" Комментарий: {launch_comment.strip()}"
 
-        notify(
+        seen, first_task = set(), None
+        for assignee in _resolve_step_users(step):
+            if assignee is None or assignee.pk in seen:
+                continue
+            seen.add(assignee.pk)
+            task = ApprovalTask.objects.create(
+                process=process,
+                step=step,
+                department=step.department,
+                kind=ApprovalTask.KIND_REVIEW,
+                assigned_to=assignee,
+                is_recheck=is_recheck,
+                parent=parent,
+            )
+            first_task = first_task or task
+            notify(
+                assignee,
+                f"{prefix}{cfg.label} {action}",
+                text=note_text,
+                url=_cabinet_url(),
+                kind=Notification.KIND_SIGN if is_sign else Notification.KIND_ACK,
+            )
 
-            assignee,
-
-            f"{prefix}{cfg.label} {action}",
-
-            text=f"«{doc_label}» — отдел «{step.department}».",
-
-            url=_cabinet_url(),
-
-            kind=Notification.KIND_SIGN if is_sign else Notification.KIND_ACK,
-
-        )
-
-        return task
+        if first_task is None:
+            # Никого не удалось определить — создаём незанятую задачу,
+            # чтобы шаг был виден администратору, а не «пропал» молча.
+            first_task = ApprovalTask.objects.create(
+                process=process,
+                step=step,
+                department=step.department,
+                kind=ApprovalTask.KIND_REVIEW,
+                assigned_to=None,
+                is_recheck=is_recheck,
+                parent=parent,
+            )
+        return first_task
 
 
 
@@ -330,6 +403,34 @@ class ApprovalEngine:
 
 
 
+        siblings_pending = (
+
+            ApprovalTask.objects
+
+            .filter(
+
+                process=process,
+
+                step=task.step,
+
+                kind=ApprovalTask.KIND_REVIEW,
+
+                status=ApprovalTask.STATUS_PENDING,
+
+            )
+
+            .exclude(pk=task.pk)
+
+            .exists()
+
+        )
+
+        if siblings_pending:
+
+            return process
+
+
+
         next_step = (
 
             process.route.steps
@@ -344,7 +445,7 @@ class ApprovalEngine:
 
         if next_step:
 
-            ApprovalEngine._create_review_task(process, next_step)
+            ApprovalEngine._create_step_tasks(process, next_step)
 
         else:
 
@@ -480,7 +581,7 @@ class ApprovalEngine:
 
 
 
-        ApprovalEngine._create_review_task(
+        ApprovalEngine._create_step_tasks(
 
             fix_task.process, fix_task.step, is_recheck=True, parent=fix_task
 
@@ -556,9 +657,7 @@ class ApprovalEngine:
 
         cert_issuer = cert_info.get("issuer_cn", "") if cert_info else ""
 
-        role_label = role_label_for_department(task.department)
-
-        position = str(task.department) if task.department else role_label
+        position = signer_department_label(user)
 
 
 
@@ -568,7 +667,7 @@ class ApprovalEngine:
 
 
 
-            role = (task.department and task.department.signature_role) or "agreed"
+            role = _rkd_role_for_department(task.department)
 
             UniversalRKDSignature.objects.update_or_create(
 
@@ -610,9 +709,9 @@ class ApprovalEngine:
 
                     "department": task.department,
 
-                    "position": role_label,
+                    "position": position,
 
-                    "role_label": role_label,
+                    "role_label": str(task.department) if task.department else "",
 
                     "signed_by": user,
 
@@ -656,7 +755,7 @@ class ApprovalEngine:
 
         cert_issuer = cert_info.get("issuer_cn", "") if cert_info else ""
 
-        position = str(task.department) if task.department else ""
+        position = signer_department_label(user)
 
 
 

--- a/approvals/sheet_service.py
+++ b/approvals/sheet_service.py
@@ -7,7 +7,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from weasyprint import HTML
 
-from .document_types import get_config_for_document
+from .document_types import get_config_for_document, signer_department_label
 from .models import ApprovalSheetRecord
 
 
@@ -24,9 +24,10 @@ def _build_rows(records) -> list[dict]:
             if rec.signed_by else "—"
         )
         date_str = rec.signed_at.strftime("%d.%m.%Y") if rec.signed_at else ""
-        position = rec.role_label or rec.position or "—"
+        position = rec.position or signer_department_label(rec.signed_by) or "—"
         rows.append({
             "number": i,
+            "role": rec.role_label or "—",
             "position": position,
             "fio": fio,
             "cert_cn": rec.cert_cn or "",
@@ -39,7 +40,7 @@ def _build_rows(records) -> list[dict]:
 def _collect_rkd_approval_rows(rkd) -> list[dict]:
     rows = []
     for i, sig in enumerate(
-        rkd.signatures.select_related("signed_by").order_by("role"), start=1
+        rkd.signatures.select_related("signed_by__profile").order_by("role"), start=1
     ):
         date_str = ""
         if getattr(sig, "signed_at", None):
@@ -57,7 +58,8 @@ def _collect_rkd_approval_rows(rkd) -> list[dict]:
         )
         rows.append({
             "number": i,
-            "position": sig.get_role_display(),
+            "role": sig.get_role_display(),
+            "position": signer_department_label(sig.signed_by) or "—",
             "fio": fio,
             "cert_cn": cert_cn,
             "cert_issuer": getattr(sig, "cert_issuer", "") or "",
@@ -72,7 +74,7 @@ def _collect_rkd_acquaintance_rows(rkd, process) -> list[dict]:
     acks = (
         UniversalRKDAcknowledgment.objects
         .filter(rkd=rkd, process=process)
-        .select_related("signed_by", "department")
+        .select_related("signed_by__profile", "department")
         .order_by("step_order", "pk")
     )
     rows = []
@@ -84,7 +86,7 @@ def _collect_rkd_acquaintance_rows(rkd, process) -> list[dict]:
         date_str = ack.signed_at.strftime("%d.%m.%Y") if ack.signed_at else ""
         rows.append({
             "number": i,
-            "position": ack.position or (str(ack.department) if ack.department else "—"),
+            "position": ack.position or signer_department_label(ack.signed_by) or "—",
             "fio": fio,
             "cert_cn": ack.cert_cn or "",
             "cert_issuer": ack.cert_issuer or "",
@@ -97,19 +99,20 @@ def _collect_generic_rows(process, sheet_type) -> list[dict]:
     records = (
         ApprovalSheetRecord.objects
         .filter(process=process, sheet_type=sheet_type)
-        .select_related("signed_by", "department")
+        .select_related("signed_by__profile", "department")
         .order_by("step_order", "pk")
     )
     return _build_rows(records)
 
 
-def _render_pdf(document, *, sheet_title: str, rows: list[dict]) -> bytes:
+def _render_pdf(document, *, sheet_title: str, rows: list[dict], show_role: bool = False) -> bytes:
     cfg = get_config_for_document(document)
     context = {
         "sheet_title": sheet_title,
         "center_line": cfg.get_center_line(document),
         "doc_info_lines": cfg.get_doc_info_lines(document),
         "rows": rows,
+        "show_role": show_role,
         "generated_at": timezone.now(),
     }
     html_string = render_to_string("pdf/workflow_sheet_template.html", context)
@@ -133,7 +136,9 @@ def generate_approval_sheet(document, process=None):
     else:
         rows = _collect_generic_rows(process, ApprovalSheetRecord.SHEET_APPROVAL)
 
-    pdf_bytes = _render_pdf(document, sheet_title="Лист утверждения", rows=rows)
+    pdf_bytes = _render_pdf(
+        document, sheet_title="Лист утверждения", rows=rows, show_role=True,
+    )
     name_part = cfg.get_center_line(document)
     return _save_pdf(
         document,

--- a/approvals/static/approvals/js/ack_step_target.js
+++ b/approvals/static/approvals/js/ack_step_target.js
@@ -1,0 +1,64 @@
+"use strict";
+
+// Маршруты ознакомления: в зависимости от выбора «Кому» (target_type)
+// в строке инлайна показываем только нужное поле:
+//   role       → поле «Роль»
+//   department → поле «Отдел»
+//   all/heads  → оба поля скрыты (адресаты вычисляются автоматически)
+(function () {
+    function toggle(field, show) {
+        if (!field) {
+            return;
+        }
+        var container =
+            field.closest(".form-row") ||
+            field.closest("td") ||
+            field.closest(".related-widget-wrapper") ||
+            field;
+        container.style.display = show ? "" : "none";
+    }
+
+    function updateRow(targetSelect) {
+        var row =
+            targetSelect.closest(".inline-related") || targetSelect.closest("tr");
+        if (!row) {
+            return;
+        }
+        var roleField = row.querySelector('select[name$="-department"]');
+        var orgField = row.querySelector('select[name$="-org_department"]');
+        var value = targetSelect.value;
+        toggle(roleField, value === "role");
+        toggle(orgField, value === "department");
+    }
+
+    function bind(targetSelect) {
+        if (!targetSelect || targetSelect.dataset.ackBound === "1") {
+            return;
+        }
+        if (targetSelect.name.indexOf("__prefix__") !== -1) {
+            return;
+        }
+        targetSelect.dataset.ackBound = "1";
+        targetSelect.addEventListener("change", function () {
+            updateRow(targetSelect);
+        });
+        updateRow(targetSelect);
+    }
+
+    function bindAll(root) {
+        (root || document)
+            .querySelectorAll('select[name$="-target_type"]')
+            .forEach(bind);
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        bindAll(document);
+    });
+
+    document.addEventListener("formset:added", function (event) {
+        var row = event.target;
+        if (row && row.querySelector) {
+            bindAll(row);
+        }
+    });
+})();

--- a/approvals/static/approvals/js/inline_order.js
+++ b/approvals/static/approvals/js/inline_order.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// Автонумерация поля "Порядок" / "Очередь замещения" в инлайнах:
+// при добавлении новой строки значение становится (максимум + 1),
+// а не дефолтной единицей.
+(function () {
+    function fieldSuffix(name) {
+        if (name.endsWith("-order")) {
+            return "-order";
+        }
+        return null;
+    }
+
+    function renumber(newInput) {
+        var suffix = fieldSuffix(newInput.name);
+        if (!suffix) {
+            return;
+        }
+        // Префикс формсета: всё до "-<index>-order".
+        var prefix = newInput.name.replace(/-\d+-order$/, "");
+        var selector =
+            'input[name^="' + prefix + '-"][name$="' + suffix + '"]';
+        var max = 0;
+        document.querySelectorAll(selector).forEach(function (inp) {
+            if (inp === newInput) {
+                return;
+            }
+            if (inp.name.indexOf("__prefix__") !== -1) {
+                return;
+            }
+            var value = parseInt(inp.value, 10);
+            if (!isNaN(value) && value > max) {
+                max = value;
+            }
+        });
+        newInput.value = max + 1;
+    }
+
+    document.addEventListener("formset:added", function (event) {
+        var row = event.target;
+        if (!row || !row.querySelector) {
+            return;
+        }
+        var orderInput = row.querySelector('input[name$="-order"]');
+        if (orderInput) {
+            renumber(orderInput);
+        }
+    });
+})();

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -106,7 +106,7 @@ from .services import WorkAssignmentService
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
 from django.contrib.auth.models import User
-from shared_repository.models import EmployeeProfile
+from shared_repository.models import Department, EmployeeProfile
 
 
 def _inject_rkd_category_json(extra_context):
@@ -1381,12 +1381,18 @@ class UniversalRKDAdmin(admin.ModelAdmin):
     change_form_template = "admin/blog/universal_rkd_category_change_form.html"
     change_list_template = "admin/blog/universalrkd/change_list.html"
     form = UniversalRKDForm
-    actions = ["send_to_approval_action"]
+    actions = ["send_to_approval_action", "send_to_acknowledgment_action"]
 
     @admin.action(description="Отправить на согласование")
     def send_to_approval_action(self, request, queryset):
         ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
-        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=rkd&ids={ids}"
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=rkd&mode=approval&ids={ids}"
+        return redirect(url)
+
+    @admin.action(description="Отправить на ознакомление")
+    def send_to_acknowledgment_action(self, request, queryset):
+        ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=rkd&mode=ack&ids={ids}"
         return redirect(url)
 
     list_display = (
@@ -4858,12 +4864,18 @@ class IndependentDocumentAcceptSignatureInline(admin.TabularInline):
 
 @admin.register(SharedRepository)
 class SharedRepositoryAdmin(admin.ModelAdmin):
-    actions = ["send_to_approval_action"]
+    actions = ["send_to_approval_action", "send_to_acknowledgment_action"]
 
     @admin.action(description="Отправить на согласование")
     def send_to_approval_action(self, request, queryset):
         ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
-        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=independent&ids={ids}"
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=independent&mode=approval&ids={ids}"
+        return redirect(url)
+
+    @admin.action(description="Отправить на ознакомление")
+    def send_to_acknowledgment_action(self, request, queryset):
+        ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=independent&mode=ack&ids={ids}"
         return redirect(url)
 
     list_display = [
@@ -5507,12 +5519,18 @@ class QMSDocumentAcceptSignatureInline(admin.TabularInline):
 
 @admin.register(QMSDocument)
 class QMSDocumentAdmin(admin.ModelAdmin):
-    actions = ["send_to_approval_action"]
+    actions = ["send_to_approval_action", "send_to_acknowledgment_action"]
 
     @admin.action(description="Отправить на согласование")
     def send_to_approval_action(self, request, queryset):
         ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
-        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=qms&ids={ids}"
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=qms&mode=approval&ids={ids}"
+        return redirect(url)
+
+    @admin.action(description="Отправить на ознакомление")
+    def send_to_acknowledgment_action(self, request, queryset):
+        ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=qms&mode=ack&ids={ids}"
         return redirect(url)
 
     list_display = [
@@ -5873,12 +5891,18 @@ class AdministrativeOrderAcceptSignatureInline(admin.TabularInline):
 
 @admin.register(AdministrativeOrder)
 class AdministrativeOrderAdmin(admin.ModelAdmin):
-    actions = ["send_to_approval_action"]
+    actions = ["send_to_approval_action", "send_to_acknowledgment_action"]
 
     @admin.action(description="Отправить на согласование")
     def send_to_approval_action(self, request, queryset):
         ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
-        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=order&ids={ids}"
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=order&mode=approval&ids={ids}"
+        return redirect(url)
+
+    @admin.action(description="Отправить на ознакомление")
+    def send_to_acknowledgment_action(self, request, queryset):
+        ids = ",".join(str(pk) for pk in queryset.values_list("pk", flat=True))
+        url = reverse("admin:approvals_approvalprocess_start") + f"?doc_type=order&mode=ack&ids={ids}"
         return redirect(url)
 
     list_display = [
@@ -6599,9 +6623,21 @@ class EmployeeProfileInline(admin.StackedInline):
             'fields': ('patronymic', 'inn', 'phone')
         }),
         ('Рабочие данные', {
-            'fields': ('department', 'position', 'supervisor', 'roles_responsibilities')
+            'fields': ('org_department', 'is_head', 'position', 'supervisor', 'roles_responsibilities')
         }),
     )
+
+
+@admin.register(Department)
+class DepartmentAdmin(admin.ModelAdmin):
+    """Справочник отделов. Скрыт из бокового меню — заполняется через «плюсик»
+    в карточке пользователя (поле «Отдел»)."""
+    list_display = ('name', 'is_active')
+    search_fields = ('name',)
+
+    def get_model_perms(self, request):
+        return {}
+
 
 admin.site.unregister(User)
 
@@ -6616,10 +6652,15 @@ class CustomUserAdmin(BaseUserAdmin):
         'get_inn',
         'get_phone',
         'get_department',
+        'get_is_head',
         'get_position',
         'get_supervisor',
         'is_active',
     )
+
+    @admin.display(description='Руководитель', boolean=True, ordering='profile__is_head')
+    def get_is_head(self, obj):
+        return obj.profile.is_head if hasattr(obj, 'profile') else False
 
     def get_patronymic(self, obj):
         return obj.profile.patronymic if hasattr(obj, 'profile') else ''
@@ -6640,10 +6681,12 @@ class CustomUserAdmin(BaseUserAdmin):
     get_phone.admin_order_field = 'profile__phone'
 
     def get_department(self, obj):
-        return obj.profile.department if hasattr(obj, 'profile') else ''
+        if hasattr(obj, 'profile') and obj.profile.org_department:
+            return obj.profile.org_department.name
+        return ''
 
     get_department.short_description = 'Отдел'
-    get_department.admin_order_field = 'profile__department'
+    get_department.admin_order_field = 'profile__org_department__name'
 
     def get_position(self, obj):
         return obj.profile.position if hasattr(obj, 'profile') else ''

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -6645,6 +6645,8 @@ admin.site.unregister(User)
 class CustomUserAdmin(BaseUserAdmin):
     inlines = [EmployeeProfileInline]
 
+    list_filter = BaseUserAdmin.list_filter + ('profile__org_department',)
+
     list_display = (
         'username',
         'get_full_name',
@@ -6685,7 +6687,7 @@ class CustomUserAdmin(BaseUserAdmin):
             return obj.profile.org_department.name
         return ''
 
-    get_department.short_description = 'Отдел'
+    get_department.short_description = 'Структурное подразделение (Отдел)'
     get_department.admin_order_field = 'profile__org_department__name'
 
     def get_position(self, obj):

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -2400,7 +2400,7 @@ class CustomerAdmin(admin.ModelAdmin):
     # Объедини фильтры в один список
     list_filter = ('name_of_company', 'revenue_for_last_year')
     list_filter = (RevenueRangeFilter,)
-    search_fields = ('name_of_company__icontains', 'address__icontains')  # Поиск по этим полям
+    search_fields = ('name_of_company', 'address', 'name_of_company_ci')
 
     def support_tickets_link(self, obj):
         """Отображение ссылки на обращения контрагента"""
@@ -2418,8 +2418,9 @@ class CustomerAdmin(admin.ModelAdmin):
 class SupportTicketInline(admin.TabularInline):
     model = SupportTicket
     extra = 0
-    fields = ('problem', 'status', 'created_date')
+    fields = ('created_date', 'category', 'problem', 'status', 'intake_channel')
     readonly_fields = ('created_date',)
+    show_change_link = True
 
 inlines = [SupportTicketInline]
 
@@ -3177,6 +3178,8 @@ class TicketCommentInline(admin.TabularInline):
     extra = 1
     fields = ['author', 'text', 'file', 'created_date']
     readonly_fields = ['created_date']
+    verbose_name = 'Запись взаимодействия'
+    verbose_name_plural = 'Взаимодействие по обработке обращений'
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related('author')
@@ -3186,30 +3189,38 @@ class TicketCommentInline(admin.TabularInline):
 @admin.register(SupportTicket)
 class SupportTicketAdmin(admin.ModelAdmin):
     form = SupportTicketForm
+    autocomplete_fields = ('customer', 'product', 'assigned_to')
     list_display = [
         'id', 'created_date', 'customer', 'product', 'get_category_display',
-        'truncated_problem', 'status_badge', 'status_changed_date',
-        'created_by', 'assigned_to', 'custom_actions'
+        'get_intake_channel_display', 'truncated_problem', 'status_badge',
+        'claim_type_display', 'status_changed_date',
+        'created_by', 'assigned_to', 'custom_actions',
     ]
     list_filter = [
-        'status', 'category', 'created_date', 'customer',
-        'product', 'assigned_to'
+        'status', 'category', 'intake_channel', 'claim_type',
+        'created_date', 'customer', 'product', 'assigned_to',
     ]
     search_fields = [
-        'problem', 'description', 'customer__name_of_company',
-        'id', 'created_by__username'
+        'problem', 'description', 'resolution', 'customer__name_of_company',
+        'id', 'created_by__username',
     ]
-    readonly_fields = ['created_date', 'status_changed_date', 'created_by']
+    readonly_fields = ['status_changed_date', 'created_by']
     inlines = [TicketCommentInline]
     date_hierarchy = 'created_date'
     list_per_page = 25
 
     fieldsets = (
-        ('Основная информация', {
-            'fields': ('customer', 'product', 'category', 'problem', 'description')
+        ('Обращение', {
+            'fields': (
+                'customer', 'product', 'category', 'problem', 'description',
+                'created_date', 'intake_channel',
+            ),
         }),
-        ('Статус и назначение', {
-            'fields': ('status', 'assigned_to', 'created_by', 'created_date', 'status_changed_date')
+        ('Обработка', {
+            'fields': (
+                'status', 'resolution', 'claim_type', 'claim_attachment',
+                'assigned_to', 'created_by', 'status_changed_date',
+            ),
         }),
     )
 
@@ -3233,6 +3244,12 @@ class SupportTicketAdmin(admin.ModelAdmin):
 
     status_badge.short_description = 'Статус'
 
+    @admin.display(description='Претензия', ordering='claim_type')
+    def claim_type_display(self, obj):
+        if not obj.claim_type:
+            return '—'
+        return obj.get_claim_type_display()
+
     def custom_actions(self, obj):
         view_url = reverse('admin:crm_supportticket_change', args=[obj.id])
         return format_html(
@@ -3242,9 +3259,16 @@ class SupportTicketAdmin(admin.ModelAdmin):
 
     custom_actions.short_description = 'Действия'
 
+    def get_changeform_initial_data(self, request):
+        initial = super().get_changeform_initial_data(request)
+        initial.setdefault('created_date', timezone.localdate())
+        return initial
+
     def save_model(self, request, obj, form, change):
-        if not obj.pk:
+        if not change:
             obj.created_by = request.user
+            if not obj.created_date:
+                obj.created_date = timezone.localdate()
         super().save_model(request, obj, form, change)
 
     def get_queryset(self, request):
@@ -3263,7 +3287,7 @@ class TicketCommentAdmin(admin.ModelAdmin):
     def truncated_text(self, obj):
         return obj.text[:100] + '...' if len(obj.text) > 100 else obj.text
 
-    truncated_text.short_description = 'Комментарий'
+    truncated_text.short_description = 'Текст'
 
     def get_queryset(self, request):
         return super().get_queryset(request).select_related('ticket', 'author')

--- a/blog/models.py
+++ b/blog/models.py
@@ -2800,9 +2800,9 @@ class UniversalRKDAcknowledgment(models.Model):
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
-        verbose_name="Отдел",
+        verbose_name="Роль",
     )
-    position = models.CharField("Должность", max_length=150, blank=True)
+    position = models.CharField("Отдел", max_length=150, blank=True)
     signed_by = models.ForeignKey(
         User,
         on_delete=models.SET_NULL,

--- a/crm/forms.py
+++ b/crm/forms.py
@@ -1,5 +1,9 @@
 from django import forms
+from django.contrib.admin.widgets import AdminDateWidget
+from django.utils import timezone
+
 from .models import TicketComment, SupportTicket
+
 
 class TicketCommentForm(forms.ModelForm):
     class Meta:
@@ -8,8 +12,8 @@ class TicketCommentForm(forms.ModelForm):
         widgets = {
             'text': forms.Textarea(attrs={
                 'rows': 4,
-                'placeholder': 'Введите комментарий...',
-                'class': 'vLargeTextField'
+                'placeholder': 'Опишите взаимодействие с заказчиком…',
+                'class': 'vLargeTextField',
             }),
         }
 
@@ -17,8 +21,65 @@ class TicketCommentForm(forms.ModelForm):
 class SupportTicketForm(forms.ModelForm):
     class Meta:
         model = SupportTicket
-        fields = ['customer', 'product', 'category', 'problem', 'description', 'status', 'assigned_to']
+        fields = [
+            'customer',
+            'product',
+            'category',
+            'problem',
+            'description',
+            'created_date',
+            'intake_channel',
+            'status',
+            'resolution',
+            'claim_type',
+            'claim_attachment',
+            'assigned_to',
+        ]
         widgets = {
+            'problem': forms.Textarea(attrs={'rows': 3, 'class': 'vLargeTextField'}),
             'description': forms.Textarea(attrs={'rows': 8, 'class': 'vLargeTextField'}),
-            'problem': forms.TextInput(attrs={'size': 60}),
+            'resolution': forms.Textarea(attrs={'rows': 6, 'class': 'vLargeTextField'}),
+            'created_date': AdminDateWidget(),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields['claim_type'].required = False
+        self.fields['created_date'].widget = AdminDateWidget()
+        if self.instance.pk and self.instance.created_date:
+            self.fields['created_date'].initial = self.instance.created_date
+        else:
+            self.fields['created_date'].initial = timezone.localdate()
+
+    def clean_created_date(self):
+        value = self.cleaned_data.get('created_date')
+        if value:
+            return value
+        if not self.instance.pk:
+            return timezone.localdate()
+        return value
+
+    def clean(self):
+        cleaned = super().clean()
+        status = cleaned.get('status')
+        resolution = (cleaned.get('resolution') or '').strip()
+        claim_type = cleaned.get('claim_type') or ''
+        claim_attachment = cleaned.get('claim_attachment')
+
+        if status == SupportTicket.STATUS_RESOLVED and not resolution:
+            self.add_error(
+                'resolution',
+                'Обязательно при статусе «Решена/Закрыта».',
+            )
+
+        if claim_type == SupportTicket.CLAIM_OFFICIAL:
+            has_attachment = bool(claim_attachment) or (
+                self.instance.pk and self.instance.claim_attachment
+            )
+            if not has_attachment:
+                self.add_error(
+                    'claim_attachment',
+                    'Для официальной претензии приложите письмо или декларацию.',
+                )
+
+        return cleaned

--- a/crm/models.py
+++ b/crm/models.py
@@ -577,6 +577,10 @@ class MeetingFile(models.Model):
         ordering = ['-uploaded_at']
 
 
+def default_intake_date():
+    return timezone.localdate()
+
+
 # Обращения техподдержки
 class SupportTicket(models.Model):
     STATUS_NEW = 'new'
@@ -591,41 +595,131 @@ class SupportTicket(models.Model):
         (STATUS_RESOLVED, 'Решена/Закрыта'),
     ]
 
+    CATEGORY_QUESTION_CONSULT = 'question_consult'
+    CATEGORY_ERROR_PROBLEM = 'error_problem'
+    CATEGORY_IMPROVEMENT = 'improvement'
+
     CATEGORY_CHOICES = [
-        ('question', 'Вопрос'),
-        ('error', 'Ошибка'),
-        ('consultation', 'Консультация'),
-        ('improvement', 'Запрос на улучшение'),
+        (CATEGORY_QUESTION_CONSULT, 'Вопрос/Консультация'),
+        (CATEGORY_ERROR_PROBLEM, 'Ошибка/Проблема'),
+        (CATEGORY_IMPROVEMENT, 'Запрос на улучшение'),
     ]
 
-    # Основные поля
-    created_date = models.DateTimeField(default=timezone.now, verbose_name='Дата поступления')
-    customer = models.ForeignKey('Customer', on_delete=models.CASCADE, verbose_name='Контрагент', related_name='support_tickets')
-    product = models.ForeignKey('Product', on_delete=models.SET_NULL, null=True, blank=True, verbose_name='Продукт')
+    INTAKE_MESSENGER = 'messenger'
+    INTAKE_EMAIL = 'email'
+    INTAKE_MAIL = 'mail'
+    INTAKE_MANAGEMENT = 'management'
+    INTAKE_PHONE_SUPPORT = 'phone_support'
+    INTAKE_PHONE = 'phone'
+    INTAKE_IN_PERSON = 'in_person'
+    INTAKE_OTHER = 'other'
 
+    INTAKE_CHANNEL_CHOICES = [
+        (INTAKE_MESSENGER, 'Мессенджер'),
+        (INTAKE_EMAIL, 'Электронная почта'),
+        (INTAKE_MAIL, 'Почта (бумажное письмо)'),
+        (INTAKE_MANAGEMENT, 'Руководство'),
+        (INTAKE_PHONE_SUPPORT, 'Телефон тех. поддержки'),
+        (INTAKE_PHONE, 'Телефон (прочее)'),
+        (INTAKE_IN_PERSON, 'Личное обращение'),
+        (INTAKE_OTHER, 'Прочее'),
+    ]
 
+    CLAIM_VERBAL = 'verbal'
+    CLAIM_OFFICIAL = 'official'
+
+    CLAIM_TYPE_CHOICES = [
+        ('', '—'),
+        (CLAIM_VERBAL, 'Устная'),
+        (CLAIM_OFFICIAL, 'Официальная'),
+    ]
+
+    created_date = models.DateField(
+        default=default_intake_date,
+        verbose_name='Дата поступления',
+    )
+    customer = models.ForeignKey(
+        'Customer',
+        on_delete=models.CASCADE,
+        verbose_name='Контрагент',
+        related_name='support_tickets',
+    )
+    product = models.ForeignKey(
+        'Product',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        verbose_name='Продукт',
+    )
     category = models.CharField(
         max_length=20,
         choices=CATEGORY_CHOICES,
         verbose_name='Категория',
-        default='question'
+        default=CATEGORY_QUESTION_CONSULT,
+    )
+    problem = models.TextField(verbose_name='Проблема')
+    description = models.TextField(verbose_name='Описание (ход решения)', blank=True)
+    intake_channel = models.CharField(
+        max_length=20,
+        choices=INTAKE_CHANNEL_CHOICES,
+        verbose_name='Как поступило',
+        blank=True,
     )
 
-    problem = models.CharField(max_length=200, verbose_name='Проблема')
-    description = models.TextField(verbose_name='Описание (ход решения)', blank=True)
-
-    # Статус и даты
-    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_NEW, verbose_name='Статус')
+    status = models.CharField(
+        max_length=20,
+        choices=STATUS_CHOICES,
+        default=STATUS_NEW,
+        verbose_name='Статус',
+    )
+    resolution = models.TextField(
+        verbose_name='Решение проблемы / причины её возникновения',
+        blank=True,
+    )
+    claim_type = models.CharField(
+        max_length=10,
+        choices=CLAIM_TYPE_CHOICES,
+        blank=True,
+        default='',
+        verbose_name='Претензия',
+    )
+    claim_attachment = models.FileField(
+        upload_to='support_tickets/claims/%Y/%m/',
+        blank=True,
+        null=True,
+        verbose_name='Письмо / декларация (претензия)',
+        validators=[validate_file_size],
+    )
     status_changed_date = models.DateTimeField(auto_now=True, verbose_name='Дата изменения статуса')
 
-    # Пользователи
-    created_by = models.ForeignKey(User, on_delete=models.SET_NULL, null=True,
-                                   related_name='created_tickets', verbose_name='Создал')
-    assigned_to = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, blank=True,
-                                    related_name='assigned_tickets', verbose_name='Назначенный агент')
+    created_by = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        related_name='created_tickets',
+        verbose_name='Создал',
+    )
+    assigned_to = models.ForeignKey(
+        User,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='assigned_tickets',
+        verbose_name='Текущий ответственный',
+    )
+
+    def clean(self):
+        super().clean()
+        if self.status == self.STATUS_RESOLVED and not (self.resolution or '').strip():
+            raise ValidationError({
+                'resolution': 'Заполните решение проблемы при статусе «Решена/Закрыта».',
+            })
+        if self.claim_type == self.CLAIM_OFFICIAL and not self.claim_attachment:
+            raise ValidationError({
+                'claim_attachment': 'Для официальной претензии приложите письмо или декларацию.',
+            })
 
     def save(self, *args, **kwargs):
-        """Автоматическое обновление даты изменения статуса"""
         if self.pk:
             original = SupportTicket.objects.get(pk=self.pk)
             if original.status != self.status:
@@ -633,12 +727,12 @@ class SupportTicket(models.Model):
         super().save(*args, **kwargs)
 
     def __str__(self):
-        return f"Обращение #{self.id} - {self.problem}"
+        return f"Обращение #{self.id} - {self.problem[:80]}"
 
     class Meta:
         verbose_name = 'Обращение'
         verbose_name_plural = 'Обращения'
-        ordering = ['-created_date']
+        ordering = ['-created_date', '-pk']
 
 
 # Комментарии к заявкам
@@ -654,7 +748,7 @@ class TicketComment(models.Model):
         return f"Комментарий к #{self.ticket.id} от {self.author.username}"
 
     class Meta:
-        verbose_name = 'Комментарий обращения'
-        verbose_name_plural = 'Комментарии обращений'
+        verbose_name = 'Запись взаимодействия'
+        verbose_name_plural = 'Взаимодействие по обработке обращений'
         ordering = ['created_date']
 

--- a/shared_repository/models.py
+++ b/shared_repository/models.py
@@ -1342,7 +1342,7 @@ class EmployeeProfile(models.Model):
         null=True,
         blank=True,
         related_name='employees',
-        verbose_name='Отдел',
+        verbose_name='Структурное подразделение (Отдел)',
     )
     is_head = models.BooleanField('Руководитель отдела', default=False)
     position = models.CharField('Должность', max_length=100, blank=True)

--- a/shared_repository/models.py
+++ b/shared_repository/models.py
@@ -1303,6 +1303,24 @@ class DocumentHistory(models.Model):
 
 # Модель для расширения стандартного пользователя Django
 
+class Department(models.Model):
+    """Организационный отдел (подразделение) компании.
+
+    Используется как справочник: в профиле сотрудника выбирается из списка,
+    а в маршрутах ознакомления можно разослать документ всему отделу разом.
+    """
+    name = models.CharField('Название отдела', max_length=150, unique=True)
+    is_active = models.BooleanField('Активен', default=True)
+
+    class Meta:
+        verbose_name = 'Отдел'
+        verbose_name_plural = 'Отделы'
+        ordering = ('name',)
+
+    def __str__(self):
+        return self.name
+
+
 class EmployeeProfile(models.Model):
     user = models.OneToOneField(
         settings.AUTH_USER_MODEL,
@@ -1318,7 +1336,15 @@ class EmployeeProfile(models.Model):
         verbose_name='ИНН',
     )
     phone = models.CharField('Телефон', max_length=20, blank=True)
-    department = models.CharField('Отдел', max_length=100, blank=True)
+    org_department = models.ForeignKey(
+        'Department',
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name='employees',
+        verbose_name='Отдел',
+    )
+    is_head = models.BooleanField('Руководитель отдела', default=False)
     position = models.CharField('Должность', max_length=100, blank=True)
     supervisor = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/templates/admin/approvals/cabinet.html
+++ b/templates/admin/approvals/cabinet.html
@@ -22,11 +22,15 @@
   }
   .cab-nav-label-icon { font-size:15px; line-height:1; }
   .cab-tabs { display:grid; gap:8px; min-width:0; }
+  .cab-tabs--4 { grid-template-columns:repeat(4, minmax(0, 1fr)); }
   .cab-tabs--3 { grid-template-columns:repeat(3, minmax(0, 1fr)); }
   .cab-tabs--2 { grid-template-columns:repeat(2, minmax(0, 1fr)); }
+  @media (max-width:900px) {
+    .cab-tabs--4 { grid-template-columns:repeat(2, minmax(0, 1fr)); }
+  }
   @media (max-width:720px) {
     .cab-nav-row { grid-template-columns:1fr; gap:8px; }
-    .cab-tabs--3, .cab-tabs--2 { grid-template-columns:1fr; }
+    .cab-tabs--4, .cab-tabs--3, .cab-tabs--2 { grid-template-columns:1fr; }
   }
   .cab-tab {
     width:100%; padding:10px 14px; cursor:pointer; border-radius:8px;
@@ -86,6 +90,67 @@
   .btn-ghost { background:transparent; color:#79aec8; border:1px solid #79aec8; }
   .btn-doc { background:#5c6bc0; }
 
+  .cab-group { margin-bottom:24px; }
+  .cab-group-head {
+    font-size:13px; font-weight:700; text-transform:uppercase; letter-spacing:.04em;
+    color:#79aec8; padding:0 2px 8px; margin-bottom:12px;
+    border-bottom:1px solid rgba(121,174,200,.25);
+    display:flex; align-items:center; gap:9px;
+  }
+  .cab-group-head .cab-group-icon { font-size:16px; line-height:1; }
+  .cab-group-count {
+    background:rgba(121,174,200,.25); color:#e8f4fa; border-radius:999px;
+    padding:1px 9px; font-size:11px; font-weight:700;
+  }
+  .cab-group-sub {
+    font-size:12px; font-weight:600; text-transform:none; letter-spacing:0;
+    color:var(--body-quiet-color,#aaa); margin-left:auto;
+  }
+  .cab-card--compact { padding:7px 12px; margin-bottom:6px; }
+  .cab-card--compact .title { font-size:13px; font-weight:600; }
+
+  /* Подзадачи: родитель + вложенные подзадачи */
+  .clamp2 {
+    display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical;
+    overflow:hidden;
+  }
+  .cab-st-group {
+    margin-bottom:18px; border:1px solid var(--hairline-color,#444);
+    border-radius:12px; overflow:hidden;
+    border-left:4px solid #5c6bc0;
+  }
+  .cab-st-parent { padding:12px 16px; background:rgba(92,107,192,.12); }
+  .cab-st-parent-head { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
+  .cab-st-code { font-size:15px; font-weight:800; color:#aeb6e8; letter-spacing:.02em; }
+  .cab-st-pill {
+    background:rgba(174,182,232,.25); color:#eef0fb; border-radius:999px;
+    padding:2px 10px; font-size:11px; font-weight:700;
+  }
+  .cab-st-parent-task {
+    margin-top:6px; font-size:12px; line-height:1.4;
+    color:var(--body-quiet-color,#9a9a9a);
+  }
+  .cab-st-caption {
+    font-size:10px; font-weight:700; letter-spacing:.06em; text-transform:uppercase;
+    color:var(--body-quiet-color,#888); padding:10px 16px 4px;
+  }
+  .cab-st-children { padding:0 14px 10px; display:flex; flex-direction:column; gap:8px; }
+  .cab-st-child {
+    display:flex; justify-content:space-between; align-items:center; gap:14px;
+    flex-wrap:wrap; padding:10px 14px; border-radius:8px;
+    border:1px solid var(--hairline-color,#444);
+    border-left:3px solid #79aec8;
+    background:var(--darkened-bg,rgba(255,255,255,.02));
+  }
+  .cab-st-child .cab-info { min-width:240px; flex:1; }
+  .cab-st-child .num {
+    display:inline-block; font-weight:700; font-size:11px; color:#9ec5d8;
+    background:rgba(121,174,200,.18); border-radius:6px; padding:1px 7px; margin-right:6px;
+  }
+  .cab-st-child .task-text { font-size:13px; font-weight:600; line-height:1.4; }
+  .cab-st-child .meta { font-size:12px; color:var(--body-quiet-color,#999); margin-top:5px; }
+  .btn-sm { padding:5px 12px; font-size:12px; }
+
   .cab-empty { padding:30px; text-align:center; color:var(--body-quiet-color,#999); font-style:italic; }
   .cab-overdue { color:#E53935; font-weight:700; }
   .notif.unread { background:rgba(33,150,243,.08); border-color:#2196F3; }
@@ -123,15 +188,25 @@
     </div>
     <div class="cab-nav-row">
       <span class="cab-nav-label"><span class="cab-nav-label-icon">📋</span> Задания</span>
-      <div class="cab-tabs cab-tabs--2">
+      <div class="cab-tabs cab-tabs--4">
+        <button type="button" class="cab-tab" data-tab="assigned">
+          <span class="cab-tab-icon" aria-hidden="true">🎯</span>
+          <span class="cab-tab-label">Мне назначено</span>
+          {% if assigned_items %}<span class="cab-badge muted">{{ assigned_items|length }}</span>{% endif %}
+        </button>
         <button type="button" class="cab-tab" data-tab="work">
           <span class="cab-tab-icon" aria-hidden="true">📥</span>
-          <span class="cab-tab-label">Мне назначено</span>
+          <span class="cab-tab-label">Мои задачи</span>
           {% if my_work %}<span class="cab-badge muted">{{ my_work|length }}</span>{% endif %}
+        </button>
+        <button type="button" class="cab-tab" data-tab="subtasks">
+          <span class="cab-tab-icon" aria-hidden="true">🧩</span>
+          <span class="cab-tab-label">Мои подзадачи</span>
+          {% if my_subtasks %}<span class="cab-badge muted">{{ my_subtasks|length }}</span>{% endif %}
         </button>
         <button type="button" class="cab-tab" data-tab="issued">
           <span class="cab-tab-icon" aria-hidden="true">📤</span>
-          <span class="cab-tab-label">Выданные</span>
+          <span class="cab-tab-label">Выданные задачи</span>
           {% if issued_work_active %}<span class="cab-badge muted">{{ issued_work_active }}</span>{% endif %}
         </button>
       </div>
@@ -163,7 +238,7 @@
           <span class="pill pill-type">{{ t.doc_ctx.type_label }}</span>
           <span class="pill pill-orange">На подпись</span>
           <span class="pill pill-blue">Шаг {{ t.process.current_order }}</span>
-          Ваша роль: <strong>{{ t.department }}</strong>
+          Ваша роль: <strong>{{ t.target_label }}</strong>
           {% if t.is_recheck %} · ⟳ повторно{% endif %}
         </div>
       </div>
@@ -193,7 +268,7 @@
           <span class="pill pill-type">{{ t.doc_ctx.type_label }}</span>
           <span class="pill pill-purple">Ознакомление</span>
           <span class="pill pill-blue">Шаг {{ t.process.current_order }}</span>
-          Отдел: <strong>{{ t.department }}</strong>
+          Роль: <strong>{{ t.target_label }}</strong>
         </div>
       </div>
       <div class="cab-actions">
@@ -220,7 +295,7 @@
         <div class="meta">
           <span class="pill pill-type">{{ t.doc_ctx.type_label }}</span>
           <span class="pill pill-orange">На доработку</span>
-          Вернул отдел: <strong>{{ t.department }}</strong>
+          Вернула роль: <strong>{{ t.target_label }}</strong>
         </div>
         {% if t.comment %}<div class="note">💬 Замечание: {{ t.comment }}</div>{% endif %}
       </div>
@@ -236,6 +311,33 @@
     </div>
     {% empty %}
     <div class="cab-empty">Нет документов на доработке.</div>
+    {% endfor %}
+  </div>
+
+  <div class="cab-panel" data-panel="assigned">
+    {% regroup assigned_items by model_label as assigned_groups %}
+    {% for group in assigned_groups %}
+    <div class="cab-group">
+      <div class="cab-group-head">
+        <span class="cab-group-icon" aria-hidden="true">📦</span>
+        {{ group.grouper }}
+        <span class="cab-group-count">{{ group.list|length }}</span>
+      </div>
+      {% for it in group.list %}
+      <div class="cab-card cab-card--compact">
+        <div class="cab-info">
+          <div class="title">{{ it.title }}</div>
+        </div>
+        <div class="cab-actions">
+          {% if it.admin_url %}
+          <a class="btn btn-gray btn-sm" href="{{ it.admin_url }}">Открыть</a>
+          {% endif %}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+    {% empty %}
+    <div class="cab-empty">Нет объектов, где вы — текущий ответственный.</div>
     {% endfor %}
   </div>
 
@@ -258,6 +360,52 @@
     </div>
     {% empty %}
     <div class="cab-empty">Нет активных заданий, назначенных вам.</div>
+    {% endfor %}
+  </div>
+
+  <div class="cab-panel" data-panel="subtasks">
+    {% for group in subtask_groups %}
+    <div class="cab-st-group">
+      <div class="cab-st-parent">
+        <div class="cab-st-parent-head">
+          <span class="cab-st-code">
+            📋 {% if group.wa %}{{ group.wa.wa_full_code|default:"Рабочее задание" }}{% else %}Без рабочего задания{% endif %}
+          </span>
+          <span class="cab-st-pill">Подзадач: {{ group.subtasks|length }}</span>
+          {% if group.wa %}
+          <a class="btn btn-ghost btn-sm" style="margin-left:auto;"
+             href="{% url 'admin:blog_workassignment_change' group.wa.pk %}">Открыть РЗ</a>
+          {% endif %}
+        </div>
+        {% if group.wa.task %}
+        <div class="cab-st-parent-task clamp2" title="{{ group.wa.task }}">{{ group.wa.task }}</div>
+        {% endif %}
+      </div>
+      <div class="cab-st-caption">Подзадачи ↓</div>
+      <div class="cab-st-children">
+        {% for st in group.subtasks %}
+        <div class="cab-st-child">
+          <div class="cab-info">
+            <div class="task-text clamp2" title="{{ st.task }}">
+              {% if st.subtask_full_code %}<span class="num">{{ st.subtask_full_code }}</span>{% endif %}
+              {{ st.task }}
+            </div>
+            <div class="meta">
+              Срок:
+              <span {% if st.target_deadline < today %}class="cab-overdue"{% endif %}>
+                {{ st.target_deadline|date:"d.m.Y" }}{% if st.target_deadline < today %} (просрочено){% endif %}
+              </span>
+            </div>
+          </div>
+          <div class="cab-actions">
+            <a class="btn btn-gray btn-sm" href="{% url 'admin:blog_workassignmentsubtask_change' st.pk %}">Открыть</a>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+    </div>
+    {% empty %}
+    <div class="cab-empty">Нет активных подзадач, назначенных вам.</div>
     {% endfor %}
   </div>
 

--- a/templates/admin/approvals/cabinet.html
+++ b/templates/admin/approvals/cabinet.html
@@ -36,13 +36,13 @@
     width:100%; padding:10px 14px; cursor:pointer; border-radius:8px;
     border:1px solid rgba(121,174,200,.45);
     background:transparent;
-    font-family:inherit; font-size:13px; font-weight:600; color:#9ec5d8;
+    font-family:inherit; font-size:13px; font-weight:600; color:var(--body-fg,#9ec5d8);
     display:flex; align-items:center; gap:10px;
     appearance:none; -webkit-appearance:none;
     transition:background .15s, border-color .15s, color .15s, box-shadow .15s;
   }
   .cab-tab:hover {
-    background:rgba(121,174,200,.14); color:#d4e8f2;
+    background:rgba(121,174,200,.14); color:var(--body-fg,#d4e8f2);
     border-color:#79aec8;
     box-shadow:0 2px 6px rgba(65,118,144,.2);
   }
@@ -54,15 +54,15 @@
   }
   .cab-tab-icon { font-size:18px; line-height:1; flex-shrink:0; width:22px; text-align:center; }
   .cab-tab.active .cab-tab-icon { transform:scale(1.05); }
-  .cab-tab-label { flex:1; text-align:left; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .cab-tab-label { flex:1; text-align:left; white-space:normal; line-height:1.2; word-break:break-word; }
   .cab-badge {
     flex-shrink:0; min-width:20px; text-align:center;
     background:#E53935; color:#fff; border-radius:999px;
     padding:2px 7px; font-size:10px; font-weight:700; line-height:1.3;
   }
   .cab-tab.active .cab-badge { background:rgba(255,255,255,.92); color:#417690; }
-  .cab-badge.muted { background:rgba(121,174,200,.35); color:#e8f4fa; }
-  .cab-tab.active .cab-badge.muted { background:rgba(255,255,255,.85); color:#417690; }
+  .cab-badge.muted { background:#417690; color:#fff; }
+  .cab-tab.active .cab-badge.muted { background:rgba(255,255,255,.92); color:#417690; }
   .cab-panel { display:none; }
   .cab-panel.active { display:block; }
 
@@ -89,6 +89,9 @@
   .btn-blue { background:#2196F3; } .btn-gray { background:#777; }
   .btn-ghost { background:transparent; color:#79aec8; border:1px solid #79aec8; }
   .btn-doc { background:#5c6bc0; }
+  .cab-wrap a.btn:link, .cab-wrap a.btn:visited { color:#fff; }
+  .cab-wrap a.btn-ghost:link, .cab-wrap a.btn-ghost:visited { color:#417690; }
+  .cab-wrap a.btn-ghost { border-color:#417690; }
 
   .cab-group { margin-bottom:24px; }
   .cab-group-head {
@@ -99,7 +102,7 @@
   }
   .cab-group-head .cab-group-icon { font-size:16px; line-height:1; }
   .cab-group-count {
-    background:rgba(121,174,200,.25); color:#e8f4fa; border-radius:999px;
+    background:#417690; color:#fff; border-radius:999px;
     padding:1px 9px; font-size:11px; font-weight:700;
   }
   .cab-group-sub {
@@ -121,9 +124,9 @@
   }
   .cab-st-parent { padding:12px 16px; background:rgba(92,107,192,.12); }
   .cab-st-parent-head { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
-  .cab-st-code { font-size:15px; font-weight:800; color:#aeb6e8; letter-spacing:.02em; }
+  .cab-st-code { font-size:15px; font-weight:800; color:#5c6bc0; letter-spacing:.02em; }
   .cab-st-pill {
-    background:rgba(174,182,232,.25); color:#eef0fb; border-radius:999px;
+    background:#5c6bc0; color:#fff; border-radius:999px;
     padding:2px 10px; font-size:11px; font-weight:700;
   }
   .cab-st-parent-task {
@@ -144,8 +147,8 @@
   }
   .cab-st-child .cab-info { min-width:240px; flex:1; }
   .cab-st-child .num {
-    display:inline-block; font-weight:700; font-size:11px; color:#9ec5d8;
-    background:rgba(121,174,200,.18); border-radius:6px; padding:1px 7px; margin-right:6px;
+    display:inline-block; font-weight:700; font-size:11px; color:#fff;
+    background:#417690; border-radius:6px; padding:1px 7px; margin-right:6px;
   }
   .cab-st-child .task-text { font-size:13px; font-weight:600; line-height:1.4; }
   .cab-st-child .meta { font-size:12px; color:var(--body-quiet-color,#999); margin-top:5px; }
@@ -191,7 +194,7 @@
       <div class="cab-tabs cab-tabs--4">
         <button type="button" class="cab-tab" data-tab="assigned">
           <span class="cab-tab-icon" aria-hidden="true">🎯</span>
-          <span class="cab-tab-label">Мне назначено</span>
+          <span class="cab-tab-label">Мне назначено (Текущий ответственный)</span>
           {% if assigned_items %}<span class="cab-badge muted">{{ assigned_items|length }}</span>{% endif %}
         </button>
         <button type="button" class="cab-tab" data-tab="work">

--- a/templates/admin/approvals/reject_task.html
+++ b/templates/admin/approvals/reject_task.html
@@ -11,7 +11,7 @@
     <div style="font-size:13px;color:var(--body-quiet-color,#aaa);margin-top:2px;">{{ doc_ctx.subtitle }}</div>
     {% endif %}
     <div style="font-size:12px;margin-top:6px;display:flex;gap:12px;flex-wrap:wrap;">
-      Отдел: <strong>{{ task.department }}</strong>
+      Роль: <strong>{{ task.target_label }}</strong>
       {% if doc_ctx.file_url %}
       <a href="{{ doc_ctx.file_url }}" target="_blank">Открыть документ →</a>
       {% endif %}

--- a/templates/admin/approvals/sign_document.html
+++ b/templates/admin/approvals/sign_document.html
@@ -86,7 +86,7 @@
     <p style="font-size:12px;font-weight:600;margin:0 0 6px;">{{ doc_type_label }}</p>
     <h3>{{ doc_title }}</h3>
     {% if doc_subtitle %}<p>{{ doc_subtitle }}</p>{% endif %}
-    <p>Отдел: <strong>{{ task.department }}</strong></p>
+    <p>Роль: <strong>{{ task.target_label }}</strong></p>
     {% if is_ack %}<p>Тип шага: <strong>Ознакомление</strong></p>{% endif %}
     <p>Маршрут: {{ task.process.route }}</p>
     <p>Файл для подписи: <strong id="sign-filename">{{ sign_filename }}</strong></p>

--- a/templates/admin/approvals/start_approval.html
+++ b/templates/admin/approvals/start_approval.html
@@ -1,33 +1,114 @@
 {% extends "admin/base_site.html" %}
 
 {% block content %}
-<div id="content-main" style="max-width:750px;">
+<div id="content-main" style="max-width:800px;">
+
+  <div style="margin-bottom:14px;">
+    <span style="display:inline-block;padding:4px 12px;border-radius:14px;font-size:12px;
+                 font-weight:700;color:#fff;
+                 background:{% if mode == 'ack' %}#7E57C2{% else %}#1E88E5{% endif %};">
+      {% if mode == 'ack' %}ОЗНАКОМЛЕНИЕ{% else %}СОГЛАСОВАНИЕ / ПОДПИСЬ{% endif %}
+    </span>
+  </div>
 
   <div style="border:1px solid var(--hairline-color,#444);border-radius:10px;
               padding:16px 20px;margin-bottom:20px;">
     <div style="font-size:13px;font-weight:600;margin-bottom:10px;opacity:.75;">
-      {{ doc_type_label }} — документы для отправки на согласование:
+      {{ doc_type_label }} — документы для отправки на {{ mode_label }}:
     </div>
     <ul style="margin:0;padding-left:18px;">
       {% for doc in documents %}
-      <li style="margin-bottom:4px;">
-        <strong>{{ doc }}</strong>
-      </li>
+      <li style="margin-bottom:4px;"><strong>{{ doc }}</strong></li>
       {% empty %}
       <li style="color:#E53935;">Документы не выбраны.</li>
       {% endfor %}
     </ul>
   </div>
 
+  {% if mode == 'ack' %}
+  <p>Выберите маршрут ознакомления. Документ получат указанные адресаты
+     (роль / весь отдел / все сотрудники / руководители).</p>
+  {% else %}
   <p>Выберите маршрут согласования — документ пройдёт по всем его шагам по порядку.</p>
+  {% endif %}
+
+  {% if routes_info %}
+  <div style="margin-bottom:18px;">
+    <button type="button" onclick="document.getElementById('routes-dialog').showModal();"
+            style="padding:8px 16px;font-size:13px;border-radius:6px;cursor:pointer;
+                   color:#fff;border:none;
+                   background:{% if mode == 'ack' %}#7E57C2{% else %}#1E88E5{% endif %};">
+      📋 Посмотреть маршруты {% if mode == 'ack' %}ознакомления{% else %}согласования{% endif %}
+      ({{ routes_info|length }})
+    </button>
+  </div>
+
+  <dialog id="routes-dialog"
+          style="max-width:640px;width:90%;border:1px solid var(--hairline-color,#444);
+                 border-radius:10px;padding:0;background:var(--body-bg,#1b1b1b);
+                 color:var(--body-fg,#eee);">
+    <div style="display:flex;justify-content:space-between;align-items:center;
+                padding:14px 18px;border-bottom:1px solid var(--hairline-color,#444);">
+      <strong style="font-size:14px;">
+        Маршруты {% if mode == 'ack' %}ознакомления{% else %}согласования{% endif %}
+      </strong>
+      <button type="button" onclick="document.getElementById('routes-dialog').close();"
+              style="background:none;border:none;color:inherit;font-size:20px;
+                     cursor:pointer;line-height:1;">&times;</button>
+    </div>
+    <div style="padding:14px 18px;max-height:65vh;overflow:auto;">
+      {% for item in routes_info %}
+      <div onclick="pickRoute('{{ item.route.pk }}');"
+           title="Нажмите, чтобы выбрать этот маршрут"
+           style="border:1px solid var(--hairline-color,#444);
+                  border-left:3px solid {% if mode == 'ack' %}#7E57C2{% else %}#1E88E5{% endif %};
+                  border-radius:6px;padding:8px 12px;margin-bottom:8px;cursor:pointer;"
+           onmouseover="this.style.background='rgba(125,125,125,.15)';"
+           onmouseout="this.style.background='';">
+        <div style="display:flex;align-items:baseline;gap:6px;">
+          <span style="font-weight:700;font-size:13px;
+                       color:{% if mode == 'ack' %}#9575CD{% else %}#64B5F6{% endif %};">
+            {{ forloop.counter }}.
+          </span>
+          <span style="font-weight:700;font-size:13px;">{{ item.route.name }}</span>
+          <span style="margin-left:auto;font-size:11px;opacity:.6;">выбрать →</span>
+        </div>
+        <div style="font-size:12px;line-height:1.5;opacity:.85;margin-top:3px;padding-left:14px;">
+          {{ item.preview }}
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </dialog>
+
+  <script>
+    function pickRoute(pk) {
+      var sel = document.getElementById("id_route");
+      if (sel) {
+        sel.value = pk;
+        sel.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+      var dlg = document.getElementById("routes-dialog");
+      if (dlg && dlg.open) {
+        dlg.close();
+      }
+    }
+  </script>
+  {% else %}
+  <p style="color:#E53935;">
+    Нет активных маршрутов {% if mode == 'ack' %}ознакомления{% else %}согласования{% endif %}.
+    Создайте их в разделе «{% if mode == 'ack' %}Маршруты ознакомления{% else %}Маршруты согласования{% endif %}».
+  </p>
+  {% endif %}
 
   <form method="post">
     {% csrf_token %}
     <input type="hidden" name="doc_type" value="{{ doc_type }}">
+    <input type="hidden" name="mode" value="{{ mode }}">
     <input type="hidden" name="ids" value="{{ ids }}">
     <table>{{ form.as_table }}</table>
     <div style="display:flex;gap:10px;margin-top:16px;">
-      <input type="submit" value="Запустить согласование" class="default"
+      <input type="submit" value="Запустить на {{ mode_label }}" class="default"
              style="padding:10px 22px;font-size:14px;">
       <a href="{% url 'admin:approvals_approvalprocess_changelist' %}"
          style="padding:10px 22px;font-size:14px;border-radius:4px;

--- a/templates/pdf/workflow_sheet_template.html
+++ b/templates/pdf/workflow_sheet_template.html
@@ -103,7 +103,7 @@
       <tr>
         <th class="num-col">№<br>п/п</th>
         {% if show_role %}<th class="role-col">Роль</th>{% endif %}
-        <th class="pos-col">Отдел</th>
+        <th class="pos-col">Структурное подразделение (Отдел)</th>
         <th class="name-col">Ф.И.О.</th>
         <th class="date-col">Дата</th>
         <th class="sig-col">Подпись</th>

--- a/templates/pdf/workflow_sheet_template.html
+++ b/templates/pdf/workflow_sheet_template.html
@@ -58,11 +58,12 @@
       text-align: center;
       background: #fff;
     }
-    td.num-col   { width: 7%; text-align: center; }
-    td.pos-col   { width: 24%; text-align: left; }
-    td.name-col  { width: 34%; text-align: left; }
-    td.date-col  { width: 13%; text-align: center; }
-    td.sig-col   { width: 22%; text-align: center; }
+    td.num-col   { width: 6%; text-align: center; }
+    td.role-col  { width: 20%; text-align: left; }
+    td.pos-col   { width: 18%; text-align: left; }
+    td.name-col  { width: 28%; text-align: left; }
+    td.date-col  { width: 12%; text-align: center; }
+    td.sig-col   { width: 16%; text-align: center; }
     .eds-badge {
       font-size: 9.5pt;
       font-weight: bold;
@@ -101,7 +102,8 @@
     <thead>
       <tr>
         <th class="num-col">№<br>п/п</th>
-        <th class="pos-col">Должность</th>
+        {% if show_role %}<th class="role-col">Роль</th>{% endif %}
+        <th class="pos-col">Отдел</th>
         <th class="name-col">Ф.И.О.</th>
         <th class="date-col">Дата</th>
         <th class="sig-col">Подпись</th>
@@ -111,6 +113,7 @@
       {% for row in rows %}
       <tr>
         <td class="num-col">{{ row.number }}</td>
+        {% if show_role %}<td class="role-col">{{ row.role|default:"—" }}</td>{% endif %}
         <td class="pos-col">{{ row.position }}</td>
         <td class="name-col">
           {{ row.fio }}
@@ -129,7 +132,7 @@
       </tr>
       {% empty %}
       <tr class="empty-row">
-        <td colspan="5">Записи не добавлены</td>
+        <td colspan="{% if show_role %}6{% else %}5{% endif %}">Записи не добавлены</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
Split approval and acquaintance routes with separate launch buttons. Acquaintance routes now broadcast by role, department, all employees, or heads (in parallel). The user "Department" became a standalone entity with a "Head" flag, "Departments" = "Roles", and a "Role" column was added to the LU sheet. The personal cabinet got tabs: "Assigned to me", "My tasks", "My subtasks" (new), and "Issued tasks".
