### PR TITLE
Update-1.0041-from-01-07-2026-(Work assignments: LK lifecycle for tasks, forms, cabinet UI; subtasks)

### DIFF
--- a/approvals/admin.py
+++ b/approvals/admin.py
@@ -182,6 +182,39 @@ def _route_steps_preview(obj):
     return format_html_join("", "{}", ((line,) for line in lines))
 
 
+_WORK_STATUS_ORDER = ("assigned", "in_progress", "review", "done")
+_WORK_STATUS_LABELS = {
+    "assigned": "Ожидает принятия",
+    "in_progress": "В работе",
+    "review": "На проверке",
+    "done": "Завершённые",
+}
+
+
+def _group_work_by_status(items):
+    buckets = {key: [] for key in _WORK_STATUS_ORDER}
+    for item in items:
+        st = item.control_status
+        if st in ("on_time", "rescheduled", "partial", "not_done"):
+            key = "done"
+        elif st == "assigned":
+            key = "assigned"
+        elif st == "review":
+            key = "review"
+        else:
+            key = "in_progress"
+        buckets[key].append(item)
+    return [
+        {
+            "key": key,
+            "label": _WORK_STATUS_LABELS[key],
+            "items": buckets[key],
+            "count": len(buckets[key]),
+        }
+        for key in _WORK_STATUS_ORDER
+    ]
+
+
 def _collect_responsible_items(user, limit_per_model=200):
     """Все объекты во всех моделях, где пользователь — «Текущий ответственный»."""
     from django.apps import apps
@@ -191,7 +224,6 @@ def _collect_responsible_items(user, limit_per_model=200):
     from django.urls import NoReverseMatch
 
     user_model = get_user_model()
-    # Рабочие задания и подзадачи показываются в отдельных вкладках ЛК.
     excluded_labels = {"blog.workassignment", "blog.workassignmentsubtask"}
     items = []
     for model in apps.get_models():
@@ -876,32 +908,52 @@ class ApprovalTaskAdmin(admin.ModelAdmin):
             else:
                 sign_tasks.append(t)
 
-        my_work = list(
+        active_filter = (
+            Q(control_status__isnull=True)
+            | Q(control_status__in=WorkAssignment.ACTIVE_STATUSES)
+        )
+        published_filter = Q(executor__isnull=False)
+
+        my_work_active = list(
             WorkAssignment.objects
             .filter(executor=user)
-            .filter(Q(control_status__isnull=True) | Q(control_status="in_progress"))
+            .filter(published_filter)
+            .filter(active_filter)
             .select_related("post")
             .order_by("target_deadline")
         )
+        my_work_done = list(
+            WorkAssignment.objects
+            .filter(executor=user, control_status__in=WorkAssignment.TERMINAL_STATUSES)
+            .filter(published_filter)
+            .select_related("post")
+            .order_by("-control_date", "-date_of_change")[:25]
+        )
+        my_work = my_work_active + my_work_done
+        my_work_groups = _group_work_by_status(my_work)
+        my_work_active_count = len(my_work_active)
 
-        issued_work_qs = (
+        issued_base = (
             WorkAssignment.objects
             .filter(author=user)
+            .filter(published_filter)
             .annotate(subtask_total=Count("subtasks"))
             .select_related("executor", "post", "current_responsible")
-            .order_by("-date_of_creation")
         )
-        issued_work = list(issued_work_qs[:50])
-        issued_work_active = issued_work_qs.filter(
-            Q(control_status__isnull=True) | Q(control_status="in_progress")
-        ).count()
+        issued_active = list(issued_base.filter(active_filter).order_by("target_deadline"))
+        issued_done = list(
+            issued_base
+            .filter(control_status__in=WorkAssignment.TERMINAL_STATUSES)
+            .order_by("-control_date", "-date_of_change")[:25]
+        )
+        issued_work = issued_active + issued_done
+        issued_work_groups = _group_work_by_status(issued_work)
+        issued_work_active = len(issued_active)
 
         my_subtasks = list(
             WorkAssignmentSubtask.objects
             .filter(executor=user)
             .filter(Q(control_status__isnull=True) | Q(control_status="in_progress"))
-            # Если основная задача закрыта (есть финальный статус) — её подзадачи
-            # считаем завершёнными и не показываем (никакой просрочки).
             .filter(
                 Q(work_assignment__control_status__isnull=True)
                 | Q(work_assignment__control_status="in_progress")
@@ -938,9 +990,12 @@ class ApprovalTaskAdmin(admin.ModelAdmin):
             "ack_tasks": ack_tasks,
             "fix_tasks": fix_tasks,
             "my_work": my_work,
+            "my_work_groups": my_work_groups,
+            "my_work_active_count": my_work_active_count,
             "my_subtasks": my_subtasks,
             "assigned_items": assigned_items,
             "issued_work": issued_work,
+            "issued_work_groups": issued_work_groups,
             "issued_work_active": issued_work_active,
             "my_docs": my_docs,
             "notifications": notifications,

--- a/approvals/admin.py
+++ b/approvals/admin.py
@@ -900,19 +900,15 @@ class ApprovalTaskAdmin(admin.ModelAdmin):
             WorkAssignmentSubtask.objects
             .filter(executor=user)
             .filter(Q(control_status__isnull=True) | Q(control_status="in_progress"))
+            # Если основная задача закрыта (есть финальный статус) — её подзадачи
+            # считаем завершёнными и не показываем (никакой просрочки).
+            .filter(
+                Q(work_assignment__control_status__isnull=True)
+                | Q(work_assignment__control_status="in_progress")
+            )
             .select_related("work_assignment", "work_assignment__post")
             .order_by("work_assignment_id", "subtask_number", "pk")
         )
-        subtask_groups, _cur = [], None
-        for st in my_subtasks:
-            if _cur is None or _cur["wa_id"] != st.work_assignment_id:
-                _cur = {
-                    "wa_id": st.work_assignment_id,
-                    "wa": st.work_assignment,
-                    "subtasks": [],
-                }
-                subtask_groups.append(_cur)
-            _cur["subtasks"].append(st)
 
         assigned_items = _collect_responsible_items(user)
 
@@ -943,7 +939,6 @@ class ApprovalTaskAdmin(admin.ModelAdmin):
             "fix_tasks": fix_tasks,
             "my_work": my_work,
             "my_subtasks": my_subtasks,
-            "subtask_groups": subtask_groups,
             "assigned_items": assigned_items,
             "issued_work": issued_work,
             "issued_work_active": issued_work_active,

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.contrib import admin, messages
 from django.contrib.admin.utils import unquote
-from django.contrib.admin.widgets import RelatedFieldWidgetWrapper
+from django.contrib.admin.widgets import RelatedFieldWidgetWrapper, AdminDateWidget
 from django.shortcuts import redirect, render
 from django.urls import path, reverse
 from django.utils import timezone
@@ -53,7 +53,12 @@ KnowledgeBase, KnowledgeBaseFile, QMSDocument,QMSDocumentAcceptSignature, Admini
 AdministrativeOrderAcceptSignature, DocumentTemplate, DocumentTemplateAcceptSignature, PSIDocument,
 GeneratedDocument, DocumentHistory)
 
-from .admin_forms import RescheduleAdminForm
+from .admin_forms import (
+    RescheduleAdminForm,
+    WorkAssignmentAdminForm,
+    WorkAssignmentCloseForm,
+    WorkAssignmentReturnForm,
+)
 from .forms import WorkAssignmentForm, UniversalRKDForm, TechnicalProposalForm
 from .helpers import (
     first_incomplete_step_code,
@@ -264,7 +269,9 @@ def _render_version_diff(text: str) -> str:
 
 
 _WA_STATUS_CIRCLE = {
+    'assigned':    ('#FFA000', None,      'Ожидает принятия'),
     'in_progress': ('#2196F3', None,      'В работе'),
+    'review':      ('#00BCD4', None,      'На проверке'),
     'on_time':     ('#4CAF50', None,      'Выполнено в срок'),
     'rescheduled': ('#4CAF50', '#FF9800', 'Выполнено с переносом сроков'),
     'partial':     ('#9C27B0', None,      'Выполнено частично'),
@@ -284,6 +291,14 @@ def _render_status_circle(status):
         '{}</span>',
         bg, label,
     )
+
+
+_WA_RESULT_TEXT = {
+    "on_time": "Выполнено в срок",
+    "rescheduled": "Выполнено с переносом сроков",
+    "partial": "Выполнено частично",
+    "not_done": "Не выполнено",
+}
 
 
 class RequiredFileGenericFormSet(BaseGenericInlineFormSet):
@@ -2343,22 +2358,35 @@ class ProtocolTechnicalProposalAdmin(admin.ModelAdmin):
         super().save_model(request, obj, form, change)
 
 class OverdueFilter(admin.SimpleListFilter):
-    title = "Просрочено?"
+    title = "Просрочен целевой срок"
     parameter_name = "overdue"
 
     def lookups(self, request, model_admin):
         return (
-            ("yes", "Просрочено"),
-            ("no", "Не просрочено"),
+            ("yes", "Просрочен"),
+            ("no", "Не просрочен"),
         )
 
     def queryset(self, request, queryset):
         if self.value() == "yes":
-            return queryset.filter(is_overdue=True)
+            return queryset.filter(is_target_overdue_db=True)
 
         if self.value() == "no":
-            return queryset.filter(is_overdue=False)
+            return queryset.filter(is_target_overdue_db=False)
 
+        return queryset
+
+
+class WorkAssignmentDraftFilter(admin.SimpleListFilter):
+    title = "Черновики"
+    parameter_name = "draft"
+
+    def lookups(self, request, model_admin):
+        return (("yes", "Черновики"),)
+
+    def queryset(self, request, queryset):
+        if self.value() == "yes":
+            return queryset.filter(executor__isnull=True)
         return queryset
 
 
@@ -3985,9 +4013,11 @@ class DeadlineChangeInline(admin.TabularInline):
     extra = 0
     can_delete = False
     readonly_fields = (
-        "old_target_deadline","old_hard_deadline","old_time_window_start","old_time_window_end",
-        "new_target_deadline","new_hard_deadline","new_time_window_start","new_time_window_end",
-        "reason","changed_by","changed_at",
+        "old_target_deadline", "old_hard_deadline",
+        "old_time_window_start", "old_time_window_end",
+        "new_target_deadline", "new_hard_deadline",
+        "new_time_window_start", "new_time_window_end",
+        "reason", "changed_by", "changed_at",
     )
     show_change_link = False
 
@@ -4079,7 +4109,7 @@ class WorkAssignmentSubtaskInline(admin.TabularInline):
 
     @admin.display(description="Просрочено?")
     def overdue_flag(self, obj):
-        active = obj.control_status in (None, 'in_progress')
+        active = obj.control_status in (None, "in_progress")
         if not active:
             return "—"
         deadline = obj.hard_deadline or obj.target_deadline
@@ -4290,15 +4320,18 @@ class WorkAssignmentSubtaskAdmin(admin.ModelAdmin):
                 kind=Notification.KIND_WORK,
             )
 
-
 @admin.register(WorkAssignment)
 class WorkAssignmentAdmin(admin.ModelAdmin):
-    #form = WorkAssignmentForm
+    form = WorkAssignmentAdminForm
+    formfield_overrides = {
+        DateField: {"widget": AdminDateWidget},
+    }
 
     list_display = (
         'wa_code_column',
         'name', 'author', 'executor', 'post',
-        'overdue_flag',
+        'overdue_target_flag',
+        'overdue_hard_flag',
         'control_status_colored',
         'control_date',
         'target_deadline', 'hard_deadline',
@@ -4313,7 +4346,7 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         'current_responsible__username',
         'post__wa_code',
     )
-    list_filter = ('control_status', OverdueFilter)
+    list_filter = ('control_status', WorkAssignmentDraftFilter, OverdueFilter)
 
     @admin.display(description='Код', ordering='post__wa_code')
     def wa_code_column(self, obj):
@@ -4324,6 +4357,7 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         'date_of_creation', 'date_of_change',
         'version', 'version_diff_display',
         'deadline_version', 'reschedule_count',
+        'control_status_display', 'control_date_display',
     )
 
     inlines = [DeadlineChangeInline, WorkAssignmentSubtaskInline, WorkAssignmentAttachmentInline]
@@ -4337,32 +4371,37 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         }),
         ('Сроки (изменять через «Перенести срок»)', {
             'fields': (
-                'target_deadline', 'hard_deadline',
-                ('time_window_start', 'time_window_end'),
+                'target_deadline',
+                'requires_hard_deadline',
+                'hard_deadline',
                 'conditional_deadline',
             )
         }),
         ('Статус выполнения / Результат', {
-            'fields': ('control_status', 'control_date', 'result_description')
+            'fields': ('control_status_display', 'control_date_display', 'result_description')
         }),
         ('Системные данные', {
             'fields': (
                 'author', 'last_editor', 'current_responsible',
                 'version', 'version_diff_display',
                 'date_of_creation', 'date_of_change',
-                'route', 'deadline_version', 'reschedule_count',
+                'deadline_version', 'reschedule_count',
             )
         }),
     )
+
+    def get_exclude(self, request, obj=None):
+        excl = list(super().get_exclude(request, obj) or [])
+        for name in ('control_status', 'control_date', 'route'):
+            if name not in excl:
+                excl.append(name)
+        return excl
 
     def get_readonly_fields(self, request, obj=None):
         fields = list(super().get_readonly_fields(request, obj))
         if obj is not None:
             for name in (
                 "target_deadline_display",
-                "hard_deadline_display",
-                "time_window_start_display",
-                "time_window_end_display",
             ):
                 if name not in fields:
                     fields.append(name)
@@ -4374,9 +4413,6 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
             return fieldsets
         rename = {
             "target_deadline": "target_deadline_display",
-            "hard_deadline": "hard_deadline_display",
-            "time_window_start": "time_window_start_display",
-            "time_window_end": "time_window_end_display",
         }
         new_fieldsets = []
         for title, opts in fieldsets:
@@ -4411,17 +4447,17 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
     def target_deadline_display(self, obj):
         return self._readonly_date_input(obj.target_deadline)
 
-    @admin.display(description="Абсолютный дедлайн")
-    def hard_deadline_display(self, obj):
-        return self._readonly_date_input(obj.hard_deadline)
+    @admin.display(description="Статус выполнения / Результат")
+    def control_status_display(self, obj):
+        if not obj or not obj.pk or not obj.control_status:
+            return "—"
+        return _render_status_circle(obj.control_status)
 
-    @admin.display(description="Временное окно: с")
-    def time_window_start_display(self, obj):
-        return self._readonly_date_input(obj.time_window_start)
-
-    @admin.display(description="Временное окно: по")
-    def time_window_end_display(self, obj):
-        return self._readonly_date_input(obj.time_window_end)
+    @admin.display(description="Дата фиксации статуса")
+    def control_date_display(self, obj):
+        if not obj or not obj.control_date:
+            return "—"
+        return obj.control_date.strftime("%d.%m.%Y")
 
     def get_changeform_initial_data(self, request):
         initial = super().get_changeform_initial_data(request)
@@ -4440,7 +4476,11 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         user = request.user
+        is_draft = "_addanother" in request.POST or (
+            "_continue" in request.POST and not obj.executor_id
+        )
         old_executor_id = None
+        old_status = None
 
         if change:
             try:
@@ -4468,18 +4508,31 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 old_status = None
 
             obj.last_editor = user
-
-            # Автоматически проставляем control_date при смене статуса
-            if obj.control_status and obj.control_status != old_status:
-                obj.control_date = timezone.localdate()
+            if is_draft:
+                obj.executor = None
+                obj.control_status = None
+                obj.control_date = None
+                obj.current_responsible = user
+            else:
+                if not old_status and obj.executor_id:
+                    obj.control_status = WorkAssignment.STATUS_ASSIGNED
+                    obj.control_date = timezone.localdate()
+                elif obj.control_status and obj.control_status != old_status:
+                    obj.control_date = timezone.localdate()
+                obj.current_responsible = obj.executor
         else:
             obj.author = user
             obj.last_editor = user
-            # Для новых записей: статус "В работе" и дата фиксации = сегодня
-            if not obj.control_status:
-                obj.control_status = "in_progress"
-            if not obj.control_date:
-                obj.control_date = timezone.localdate()
+            if is_draft:
+                obj.executor = None
+                obj.control_status = None
+                obj.control_date = None
+                obj.current_responsible = user
+            else:
+                if not obj.control_status:
+                    obj.control_status = WorkAssignment.STATUS_ASSIGNED
+                    obj.control_date = timezone.localdate()
+                obj.current_responsible = obj.executor or user
 
         if obj.post_id:
             from .helpers import assign_wa_code_to_post, next_wa_number_for_post
@@ -4489,7 +4542,12 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
 
         super().save_model(request, obj, form, change)
 
-        if obj.executor_id and obj.executor_id != old_executor_id and obj.executor_id != user.id:
+        if (
+            not is_draft
+            and obj.executor_id
+            and obj.executor_id != old_executor_id
+            and obj.executor_id != user.id
+        ):
             from approvals.services import notify
             from approvals.models import Notification
             notify(
@@ -4500,45 +4558,88 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 kind=Notification.KIND_WORK,
             )
 
+    def response_add(self, request, obj, post_url_continue=None):
+        if "_addanother" in request.POST:
+            return redirect(f"{reverse('admin:blog_workassignment_changelist')}?draft=yes")
+        return super().response_add(request, obj, post_url_continue)
+
+    def response_change(self, request, obj):
+        if "_addanother" in request.POST:
+            return redirect(f"{reverse('admin:blog_workassignment_changelist')}?draft=yes")
+        return super().response_change(request, obj)
+
+    @staticmethod
+    def _is_changelist_request(request):
+        match = getattr(request, "resolver_match", None)
+        return match is not None and match.url_name == "blog_workassignment_changelist"
+
     def get_queryset(self, request):
         qs = super().get_queryset(request)
+        if self._is_changelist_request(request) and request.GET.get("draft") != "yes":
+            qs = qs.exclude(executor__isnull=True)
 
         today = timezone.localdate()
 
-        qs = qs.annotate(
-            effective_deadline_db=Case(
-                When(hard_deadline__isnull=False, then=F("hard_deadline")),
-                default=F("target_deadline"),
-                output_field=DateField(),
-            )
+        active_q = (
+            Q(control_status__isnull=True)
+            | Q(control_status__in=WorkAssignment.ACTIVE_STATUSES)
         )
-
-        # Просрочено: нет статуса ИЛИ статус «В работе» + срок прошёл
         qs = qs.annotate(
-            is_overdue=Case(
+            is_target_overdue_db=Case(
                 When(
-                    Q(control_status__isnull=True) | Q(control_status="in_progress"),
-                    then=Case(
-                        When(effective_deadline_db__lt=today, then=True),
-                        default=False,
-                        output_field=BooleanField(),
-                    ),
+                    active_q & Q(target_deadline__lt=today),
+                    then=True,
                 ),
                 default=False,
                 output_field=BooleanField(),
-            )
+            ),
+            is_hard_overdue_db=Case(
+                When(
+                    active_q
+                    & Q(hard_deadline__isnull=False)
+                    & Q(hard_deadline__lt=today),
+                    then=True,
+                ),
+                default=False,
+                output_field=BooleanField(),
+            ),
         )
 
         return qs
 
+    @admin.display(description="Просрочен целевой срок")
+    def overdue_target_flag(self, obj):
+        overdue = getattr(obj, "is_target_overdue_db", None)
+        if overdue is None:
+            overdue = obj.is_target_overdue()
+        if overdue:
+            return mark_safe(
+                _admin_warning_triangle_html(
+                    title="Целевой срок выполнения просрочен",
+                    color="#f0ad4e",
+                )
+            )
+        return "—"
+
+    @admin.display(description="Просрочен абсолютный дедлайн")
+    def overdue_hard_flag(self, obj):
+        if not obj.hard_deadline:
+            return "—"
+        overdue = getattr(obj, "is_hard_overdue_db", None)
+        if overdue is None:
+            overdue = obj.is_hard_overdue()
+        if overdue:
+            return mark_safe(
+                _admin_warning_triangle_html(
+                    title="Абсолютный дедлайн просрочен",
+                    color="#E53935",
+                )
+            )
+        return "—"
+
     @admin.display(description="Статус выполнения / Результат", ordering="control_status")
     def control_status_colored(self, obj):
         return _render_status_circle(obj.control_status)
-
-    @admin.display(description="Просрочено?")
-    def overdue_flag(self, obj):
-        active = obj.control_status in (None, 'in_progress')
-        return "⚠️" if (active and obj.is_overdue) else "—"
 
     @admin.display(description="История изменений")
     def version_diff_display(self, obj):
@@ -4554,8 +4655,210 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 self.admin_site.admin_view(self.reschedule_view),
                 name="blog_workassignment_reschedule",
             ),
+            path(
+                "<int:object_id>/acknowledge/",
+                self.admin_site.admin_view(self.acknowledge_view),
+                name="blog_workassignment_acknowledge",
+            ),
+            path(
+                "<int:object_id>/submit-review/",
+                self.admin_site.admin_view(self.submit_review_view),
+                name="blog_workassignment_submit_review",
+            ),
+            path(
+                "<int:object_id>/close/",
+                self.admin_site.admin_view(self.close_view),
+                name="blog_workassignment_close",
+            ),
+            path(
+                "<int:object_id>/return/",
+                self.admin_site.admin_view(self.return_view),
+                name="blog_workassignment_return",
+            ),
         ]
         return custom + urls
+
+    @staticmethod
+    def _wa_label(obj):
+        return obj.wa_full_code or obj.name or (obj.task or "").strip()[:80] or str(obj)
+
+    def _notify_wa(self, recipient, title, text, obj):
+        if not recipient:
+            return
+        from approvals.services import notify
+        from approvals.models import Notification
+        notify(
+            recipient,
+            title,
+            text=text,
+            url=reverse("admin:blog_workassignment_change", args=[obj.pk]),
+            kind=Notification.KIND_WORK,
+        )
+
+    def acknowledge_view(self, request, object_id: int):
+        from django.shortcuts import redirect, get_object_or_404
+        obj = get_object_or_404(WorkAssignment, pk=object_id)
+        back = redirect("admin:approvals_cabinet")
+        if request.user.id != obj.executor_id:
+            messages.error(request, "Принять задачу в работу может только её исполнитель.")
+            return back
+        if obj.control_status != WorkAssignment.STATUS_ASSIGNED:
+            messages.warning(request, "Задача уже не ожидает принятия.")
+            return back
+        if request.method != "POST":
+            return back
+        obj.control_status = WorkAssignment.STATUS_IN_PROGRESS
+        obj.control_date = timezone.localdate()
+        obj.current_responsible = obj.executor
+        obj.last_editor = request.user
+        obj.save(update_fields=[
+            "control_status", "control_date", "current_responsible", "last_editor", "date_of_change",
+        ])
+        self._notify_wa(
+            obj.author,
+            "Исполнитель приступил к задаче",
+            f"«{self._wa_label(obj)}» взята в работу.",
+            obj,
+        )
+        messages.success(request, "Задача принята в работу.")
+        return back
+
+    def submit_review_view(self, request, object_id: int):
+        from django.shortcuts import redirect, get_object_or_404
+        obj = get_object_or_404(WorkAssignment, pk=object_id)
+        back = redirect("admin:approvals_cabinet")
+        if request.user.id != obj.executor_id:
+            messages.error(request, "Сдать задачу может только её исполнитель.")
+            return back
+        if obj.control_status != WorkAssignment.STATUS_IN_PROGRESS:
+            messages.warning(request, "Сдать на проверку можно только задачу в работе.")
+            return back
+        if request.method != "POST":
+            return back
+        obj.control_status = WorkAssignment.STATUS_REVIEW
+        obj.control_date = timezone.localdate()
+        obj.current_responsible = obj.author
+        obj.last_editor = request.user
+        obj.save(update_fields=[
+            "control_status", "control_date", "current_responsible", "last_editor", "date_of_change",
+        ])
+        self._notify_wa(
+            obj.author,
+            "Задача сдана на проверку",
+            f"«{self._wa_label(obj)}» ожидает вашей проверки.",
+            obj,
+        )
+        messages.success(request, "Задача отправлена автору на проверку.")
+        return back
+
+    _CLOSE_STATUS_BY_CHOICE = {
+        "partial": "partial",
+        "not_done": "not_done",
+    }
+    _RESULT_TEXT = _WA_RESULT_TEXT
+
+    def close_view(self, request, object_id: int):
+        from django.shortcuts import render, redirect, get_object_or_404
+        obj = get_object_or_404(WorkAssignment, pk=object_id)
+        back = redirect("admin:approvals_cabinet")
+        if request.user.id != obj.author_id:
+            messages.error(request, "Закрыть задачу может только её автор.")
+            return back
+        if obj.control_status not in WorkAssignment.ACTIVE_STATUSES:
+            messages.warning(request, "Эта задача уже закрыта.")
+            return back
+
+        if request.method == "POST":
+            form = WorkAssignmentCloseForm(request.POST)
+            if form.is_valid():
+                choice = form.cleaned_data["result"]
+                comment = form.cleaned_data.get("comment", "").strip()
+                if choice == "done":
+                    status = "rescheduled" if obj.reschedule_count else "on_time"
+                else:
+                    status = self._CLOSE_STATUS_BY_CHOICE[choice]
+                obj.control_status = status
+                obj.control_date = timezone.localdate()
+                obj.result = self._RESULT_TEXT.get(status)
+                obj.current_responsible = obj.author
+                obj.last_editor = request.user
+                fields = [
+                    "control_status", "control_date", "result",
+                    "current_responsible", "last_editor", "date_of_change",
+                ]
+                if comment:
+                    obj.result_description = comment
+                    fields.append("result_description")
+                obj.save(update_fields=fields)
+                self._notify_wa(
+                    obj.executor,
+                    "Задача проверена и закрыта",
+                    f"«{self._wa_label(obj)}»: {self._RESULT_TEXT.get(status)}."
+                    + (f" Комментарий: {comment}" if comment else ""),
+                    obj,
+                )
+                messages.success(
+                    request,
+                    f"Задача закрыта со статусом «{self._RESULT_TEXT.get(status)}».",
+                )
+                return back
+        else:
+            form = WorkAssignmentCloseForm()
+
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "original": obj,
+            "title": "Проверить и закрыть задачу",
+            "form": form,
+            "object_id": object_id,
+            "rescheduled_note": bool(obj.reschedule_count),
+        }
+        return render(request, "admin/blog/workassignment/close.html", context)
+
+    def return_view(self, request, object_id: int):
+        from django.shortcuts import render, redirect, get_object_or_404
+        obj = get_object_or_404(WorkAssignment, pk=object_id)
+        back = redirect("admin:approvals_cabinet")
+        if request.user.id != obj.author_id:
+            messages.error(request, "Вернуть задачу может только её автор.")
+            return back
+        if obj.control_status != WorkAssignment.STATUS_REVIEW:
+            messages.warning(request, "Вернуть на доработку можно только задачу на проверке.")
+            return back
+
+        if request.method == "POST":
+            form = WorkAssignmentReturnForm(request.POST)
+            if form.is_valid():
+                comment = form.cleaned_data.get("comment", "").strip()
+                obj.control_status = WorkAssignment.STATUS_IN_PROGRESS
+                obj.control_date = timezone.localdate()
+                obj.current_responsible = obj.executor
+                obj.last_editor = request.user
+                obj.save(update_fields=[
+                    "control_status", "control_date", "current_responsible", "last_editor", "date_of_change",
+                ])
+                self._notify_wa(
+                    obj.executor,
+                    "Задача возвращена на доработку",
+                    f"«{self._wa_label(obj)}» возвращена автором."
+                    + (f" Комментарий: {comment}" if comment else ""),
+                    obj,
+                )
+                messages.success(request, "Задача возвращена исполнителю на доработку.")
+                return back
+        else:
+            form = WorkAssignmentReturnForm()
+
+        context = {
+            **self.admin_site.each_context(request),
+            "opts": self.model._meta,
+            "original": obj,
+            "title": "Вернуть задачу на доработку",
+            "form": form,
+            "object_id": object_id,
+        }
+        return render(request, "admin/blog/workassignment/return.html", context)
 
     def reschedule_view(self, request, object_id: int):
         from django.shortcuts import render, redirect, get_object_or_404
@@ -4565,12 +4868,9 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
             form = RescheduleAdminForm(request.POST)
             if form.is_valid():
                 try:
-                    WorkAssignmentService.reschedule_deadline(
+                    assignment = WorkAssignmentService.reschedule_deadline(
                         obj,
                         new_target_deadline=form.cleaned_data.get("new_target_deadline"),
-                        new_hard_deadline=form.cleaned_data.get("new_hard_deadline"),
-                        new_time_window_start=form.cleaned_data.get("new_time_window_start"),
-                        new_time_window_end=form.cleaned_data.get("new_time_window_end"),
                         reason=form.cleaned_data.get("reason", ""),
                         user=request.user if request.user.is_authenticated else None,
                         expected_deadline_version=form.cleaned_data["expected_deadline_version"],
@@ -4580,14 +4880,18 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 except RuntimeError as e:
                     messages.error(request, str(e))  # конфликт версий
                 else:
-                    messages.success(request, "Срок успешно перенесён.")
+                    if getattr(assignment, "_hard_deadline_reset", False):
+                        messages.warning(
+                            request,
+                            "Целевой срок перенесён. Абсолютный дедлайн сброшен — "
+                            "при необходимости назначьте его заново в карточке задания.",
+                        )
+                    else:
+                        messages.success(request, "Срок успешно перенесён.")
                     return redirect(f"../change/")
         else:
             form = RescheduleAdminForm(initial={
                 "new_target_deadline": obj.target_deadline,
-                "new_hard_deadline": obj.hard_deadline,
-                "new_time_window_start": obj.time_window_start,
-                "new_time_window_end": obj.time_window_end,
                 "expected_deadline_version": obj.deadline_version,
             })
 
@@ -4598,6 +4902,7 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
             "title": "Перенести срок",
             "form": form,
             "object_id": object_id,
+            "had_hard_deadline": bool(obj.hard_deadline),
             "has_view_permission": self.has_view_permission(request, obj),
             "has_change_permission": self.has_change_permission(request, obj),
         }

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -105,6 +105,7 @@ from .services import WorkAssignmentService
 
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from django.contrib.auth.forms import UserChangeForm
 from django.contrib.auth.models import User
 from shared_repository.models import Department, EmployeeProfile
 
@@ -1406,6 +1407,7 @@ class UniversalRKDAdmin(admin.ModelAdmin):
         "display_lu_lo_sheets",
         "quantity",
         "note",
+        "rkd_planned_review_date",
         "rkd_planned_review_warning",
     )
     list_display_links = ("name",)
@@ -1450,7 +1452,16 @@ class UniversalRKDAdmin(admin.ModelAdmin):
         return _admin_lu_lo_sheets_column_html(obj)
 
     @admin.display(
-        description="Оповещение о пересмотре",
+        description="Дата планового пересмотра",
+        ordering="validity_date",
+    )
+    def rkd_planned_review_date(self, obj):
+        if not obj.validity_date:
+            return "—"
+        return obj.validity_date.strftime("%d.%m.%Y")
+
+    @admin.display(
+        description="Срок пересмотра истекает",
         ordering="validity_date",
     )
     def rkd_planned_review_warning(self, obj):
@@ -4007,7 +4018,7 @@ class WorkAssignmentSubtaskInline(admin.TabularInline):
         "target_deadline",
         "task_preview",
         "criteria_preview",
-        "control_status_colored",
+        "control_status",
         "overdue_flag",
         "comment_preview",
     )
@@ -4018,7 +4029,6 @@ class WorkAssignmentSubtaskInline(admin.TabularInline):
         "target_deadline",
         "task_preview",
         "criteria_preview",
-        "control_status_colored",
         "overdue_flag",
         "comment_preview",
     )
@@ -6613,19 +6623,49 @@ class DocumentHistoryAdmin(admin.ModelAdmin):
         return False
 
 #Модель пользовательского разделе с доп информацией
-class EmployeeProfileInline(admin.StackedInline):
-    model = EmployeeProfile
-    fk_name = 'user'
-    can_delete = False
-    verbose_name_plural = 'Дополнительная информация'
-    fieldsets = (
-        ('Личные данные', {
-            'fields': ('patronymic', 'inn', 'phone')
-        }),
-        ('Рабочие данные', {
-            'fields': ('org_department', 'is_head', 'position', 'supervisor', 'roles_responsibilities')
-        }),
+class UserWithProfileForm(UserChangeForm):
+    """Поля профиля сотрудника (EmployeeProfile) """
+    patronymic = forms.CharField(label='Отчество', max_length=100, required=False)
+    phone = forms.CharField(label='Телефон', max_length=20, required=False)
+    org_department = forms.ModelChoiceField(
+        label='Структурное подразделение (Отдел)',
+        queryset=Department.objects.all(),
+        required=False,
     )
+    is_head = forms.BooleanField(label='Руководитель отдела', required=False)
+    position = forms.CharField(label='Должность', max_length=100, required=False)
+    supervisor = forms.ModelChoiceField(
+        label='Непосредственное подчинение',
+        queryset=User.objects.all(),
+        required=False,
+    )
+    roles_responsibilities = forms.CharField(
+        label='Роли / обязанности',
+        widget=forms.Textarea(attrs={'rows': 3}),
+        required=False,
+    )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        profile = getattr(self.instance, 'profile', None) if self.instance.pk else None
+        if profile:
+            self.fields['patronymic'].initial = profile.patronymic
+            self.fields['phone'].initial = profile.phone
+            self.fields['org_department'].initial = profile.org_department_id
+            self.fields['is_head'].initial = profile.is_head
+            self.fields['position'].initial = profile.position
+            self.fields['supervisor'].initial = profile.supervisor_id
+            self.fields['roles_responsibilities'].initial = profile.roles_responsibilities
+
+        # Кнопка «+» для добавления нового подразделения прямо из карточки.
+        dep_rel = EmployeeProfile._meta.get_field('org_department').remote_field
+        self.fields['org_department'].widget = RelatedFieldWidgetWrapper(
+            self.fields['org_department'].widget,
+            dep_rel,
+            admin.site,
+            can_add_related=True,
+            can_change_related=True,
+        )
 
 
 @admin.register(Department)
@@ -6643,7 +6683,43 @@ admin.site.unregister(User)
 
 @admin.register(User)
 class CustomUserAdmin(BaseUserAdmin):
-    inlines = [EmployeeProfileInline]
+    form = UserWithProfileForm
+
+    _PROFILE_FIELDS = (
+        'patronymic', 'phone', 'org_department',
+        'is_head', 'position', 'supervisor', 'roles_responsibilities',
+    )
+
+    fieldsets = (
+        (None, {'fields': ('username', 'password')}),
+        ('Персональные данные', {
+            'fields': ('first_name', 'last_name', 'patronymic', 'phone', 'email'),
+        }),
+        ('Профиль сотрудника', {
+            'fields': ('org_department', 'is_head', 'position', 'supervisor', 'roles_responsibilities'),
+        }),
+        ('Права доступа', {
+            'classes': ('collapse',),
+            'fields': ('is_active', 'is_staff', 'is_superuser', 'groups', 'user_permissions'),
+        }),
+        ('Важные даты', {
+            'classes': ('collapse',),
+            'fields': ('last_login', 'date_joined'),
+        }),
+    )
+
+    def save_model(self, request, obj, form, change):
+        super().save_model(request, obj, form, change)
+        if any(f in form.cleaned_data for f in self._PROFILE_FIELDS):
+            profile, _ = EmployeeProfile.objects.get_or_create(user=obj)
+            profile.patronymic = form.cleaned_data.get('patronymic', '')
+            profile.phone = form.cleaned_data.get('phone', '')
+            profile.org_department = form.cleaned_data.get('org_department')
+            profile.is_head = form.cleaned_data.get('is_head', False)
+            profile.position = form.cleaned_data.get('position', '')
+            profile.supervisor = form.cleaned_data.get('supervisor')
+            profile.roles_responsibilities = form.cleaned_data.get('roles_responsibilities', '')
+            profile.save()
 
     list_filter = BaseUserAdmin.list_filter + ('profile__org_department',)
 
@@ -6651,7 +6727,7 @@ class CustomUserAdmin(BaseUserAdmin):
         'username',
         'get_full_name',
         'get_patronymic',
-        'get_inn',
+        'email',
         'get_phone',
         'get_department',
         'get_is_head',
@@ -6659,6 +6735,11 @@ class CustomUserAdmin(BaseUserAdmin):
         'get_supervisor',
         'is_active',
     )
+
+    @admin.display(description='Фамилия. Имя', ordering='last_name')
+    def get_full_name(self, obj):
+        name = f"{obj.last_name} {obj.first_name}".strip()
+        return name or obj.username
 
     @admin.display(description='Руководитель', boolean=True, ordering='profile__is_head')
     def get_is_head(self, obj):
@@ -6669,12 +6750,6 @@ class CustomUserAdmin(BaseUserAdmin):
 
     get_patronymic.short_description = 'Отчество'
     get_patronymic.admin_order_field = 'profile__patronymic'
-
-    def get_inn(self, obj):
-        return obj.profile.inn if hasattr(obj, 'profile') else ''
-
-    get_inn.short_description = 'ИНН'
-    get_inn.admin_order_field = 'profile__inn'
 
     def get_phone(self, obj):
         return obj.profile.phone if hasattr(obj, 'profile') else ''

--- a/blog/admin_forms.py
+++ b/blog/admin_forms.py
@@ -1,13 +1,153 @@
 from django import forms
+from django.contrib.admin.widgets import AdminDateWidget
+
+from .models import WorkAssignment, _as_date, _INVALID_DATE_MSG
+
+
+class WorkAssignmentAdminForm(forms.ModelForm):
+    requires_hard_deadline = forms.BooleanField(
+        required=False,
+        initial=False,
+        label="Требуется установить абсолютный дедлайн?",
+    )
+
+    class Meta:
+        model = WorkAssignment
+        fields = "__all__"
+        widgets = {
+            "conditional_deadline": forms.Textarea(attrs={"rows": 4, "cols": 80}),
+        }
+        labels = {
+            "hard_deadline": "Установить дедлайн",
+            "conditional_deadline": "Условия/ограничения",
+        }
+        help_texts = {
+            "hard_deadline": (
+                "Дата абсолютного дедлайна должна быть не раньше целевого срока выполнения."
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        instance = getattr(self, "instance", None)
+        if instance and instance.pk:
+            self.fields["requires_hard_deadline"].initial = bool(instance.hard_deadline)
+        if "executor" in self.fields:
+            self.fields["executor"].required = False
+
+    def clean(self):
+        cleaned = super().clean()
+        requires = cleaned.get("requires_hard_deadline")
+        hard_raw = cleaned.get("hard_deadline")
+        target_raw = cleaned.get("target_deadline")
+
+        for field_name, raw in (
+            ("target_deadline", target_raw),
+            ("hard_deadline", hard_raw),
+            ("time_window_start", cleaned.get("time_window_start")),
+            ("time_window_end", cleaned.get("time_window_end")),
+        ):
+            if raw in (None, ""):
+                continue
+            if _as_date(raw) is None:
+                self.add_error(
+                    field_name,
+                    _INVALID_DATE_MSG,
+                )
+
+        hard = _as_date(hard_raw)
+        target = _as_date(target_raw)
+        for field_name in ("time_window_start", "time_window_end"):
+            coerced = _as_date(cleaned.get(field_name))
+            if coerced is not None:
+                cleaned[field_name] = coerced
+        if hard is not None:
+            cleaned["hard_deadline"] = hard
+        if target is not None:
+            cleaned["target_deadline"] = target
+
+        if not requires:
+            cleaned["hard_deadline"] = None
+        elif not hard:
+            self.add_error(
+                "hard_deadline",
+                "Укажите дату абсолютного дедлайна или снимите галочку.",
+            )
+        elif target and hard < target:
+            self.add_error(
+                "hard_deadline",
+                "Абсолютный дедлайн не может быть раньше целевого срока выполнения.",
+            )
+
+        action = self._save_action()
+        executor = cleaned.get("executor")
+        if action == "draft":
+            if executor:
+                self.add_error(
+                    "executor",
+                    "Черновик сохраняется без исполнителя. Очистите поле «Исполнитель».",
+                )
+            if self.instance.pk and self.instance.executor_id:
+                self.add_error(
+                    None,
+                    "Отправленное рабочее задание нельзя сохранить как черновик.",
+                )
+        elif action == "publish" and not executor:
+            self.add_error(
+                "executor",
+                "Укажите исполнителя для отправки рабочего задания.",
+            )
+        elif action == "continue":
+            if not executor and self.instance.pk and self.instance.executor_id:
+                self.add_error(
+                    "executor",
+                    "У отправленного рабочего задания нельзя убрать исполнителя.",
+                )
+        return cleaned
+
+    def _save_action(self):
+        if not self.data:
+            return None
+        if "_addanother" in self.data:
+            return "draft"
+        if "_save" in self.data:
+            return "publish"
+        if "_continue" in self.data:
+            return "continue"
+        return None
+
 
 class RescheduleAdminForm(forms.Form):
-    new_target_deadline   = forms.DateField(required=False, label="Новый целевой срок",
-                                            widget=forms.DateInput(attrs={'type': 'date'}))
-    new_hard_deadline     = forms.DateField(required=False, label="Новый абсолютный срок",
-                                            widget=forms.DateInput(attrs={'type': 'date'}))
-    new_time_window_start = forms.DateField(required=False, label="Окно: с",
-                                            widget=forms.DateInput(attrs={'type': 'date'}))
-    new_time_window_end   = forms.DateField(required=False, label="Окно: по",
-                                            widget=forms.DateInput(attrs={'type': 'date'}))
+    new_target_deadline = forms.DateField(
+        required=False,
+        label="Новый целевой срок",
+        widget=AdminDateWidget,
+    )
     reason = forms.CharField(label="Причина", widget=forms.TextInput(attrs={"size": 80}))
     expected_deadline_version = forms.IntegerField(widget=forms.HiddenInput)
+
+
+class WorkAssignmentCloseForm(forms.Form):
+    RESULT_CHOICES = [
+        ("done", "Выполнено"),
+        ("partial", "Выполнено частично"),
+        ("not_done", "Не выполнено"),
+    ]
+    result = forms.ChoiceField(
+        choices=RESULT_CHOICES,
+        widget=forms.RadioSelect,
+        label="Результат проверки",
+    )
+    comment = forms.CharField(
+        required=False,
+        label="Комментарий (необязательно)",
+        widget=forms.Textarea(attrs={"rows": 3, "cols": 60}),
+    )
+
+
+class WorkAssignmentReturnForm(forms.Form):
+    comment = forms.CharField(
+        required=False,
+        label="Что нужно доработать",
+        widget=forms.Textarea(attrs={"rows": 3, "cols": 60}),
+    )

--- a/blog/models.py
+++ b/blog/models.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from django.db.models import Max
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from datetime import date, datetime
 
 from .helpers import (
     SPECIFICATION_SECTION_CHOICES,
@@ -20,6 +21,33 @@ from .helpers import (
 
 User = settings.AUTH_USER_MODEL
 User = get_user_model()
+
+_INVALID_DATE_MSG = "Укажите дату в формате ДД.ММ.ГГГГ (например, 01.07.2026)."
+
+
+def _as_date(value):
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    return None
+
+
+def _normalize_model_dates(instance, field_names):
+    normalized = {}
+    errors = {}
+    for name in field_names:
+        raw = getattr(instance, name, None)
+        coerced = _as_date(raw)
+        if raw not in (None, "") and coerced is None:
+            errors[name] = _INVALID_DATE_MSG
+        else:
+            normalized[name] = coerced
+            if coerced is not None:
+                setattr(instance, name, coerced)
+    return normalized, errors
 
 
 class technical_design(models.Model):
@@ -1606,14 +1634,22 @@ class WorkAssignment(models.Model):
     ]
 
     TEMP_STATUS_CHOICES = [
+        ('assigned', 'Ожидает принятия'),
         ('in_progress', 'В работе'),
+        ('review', 'На проверке'),
         ('on_time', 'Выполнено в срок'),
         ('rescheduled', 'Выполнено с переносом сроков'),
         ('partial', 'Выполнено частично'),
         ('not_done', 'Не выполнено (Отменено)'),
     ]
 
-    # базовые поля
+    STATUS_ASSIGNED = 'assigned'
+    STATUS_IN_PROGRESS = 'in_progress'
+    STATUS_REVIEW = 'review'
+
+    ACTIVE_STATUSES = ('assigned', 'in_progress', 'review')
+    TERMINAL_STATUSES = ('on_time', 'rescheduled', 'partial', 'not_done')
+
     name = models.CharField(max_length=100, unique=True, blank=True, null=True, verbose_name="Наименование")
     wa_number = models.PositiveIntegerField(
         null=True,
@@ -1623,7 +1659,6 @@ class WorkAssignment(models.Model):
     )
     category = models.CharField(max_length=100, default="РЗ", verbose_name="Категория")
     executor = models.ForeignKey(User, on_delete=models.CASCADE, null= True, related_name= "executed_workassignments", verbose_name="Исполнитель")
-    task = models.CharField('Задача', max_length=255, blank=True)
     post = models.ForeignKey('Post', on_delete=models.CASCADE, null=True, blank=True, related_name='work_assignments', verbose_name="Связанная разработка/проект")
     author = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name="Автор")
     date_of_creation = models.DateTimeField(default=timezone.now, verbose_name="Дата и время создания")
@@ -1654,12 +1689,11 @@ class WorkAssignment(models.Model):
     result_description = models.TextField(max_length=5000, blank=True, null=True, verbose_name="Описание результата")
     route = models.ForeignKey("Route", on_delete=models.CASCADE, related_name='routes', blank=True, null=True, verbose_name="Маршрут")
 
-    target_deadline = models.DateField("Целевой срок выполнения", default=timezone.now, null=False, blank=False)
+    target_deadline = models.DateField("Целевой срок выполнения", default=timezone.localdate, null=False, blank=False)
     hard_deadline = models.DateField("Абсолютный дедлайн", null=True, blank=True)
     time_window_start = models.DateField("Временное окно: с", null=True, blank=True)
     time_window_end = models.DateField("Временное окно: по", null=True, blank=True)
-    conditional_deadline = models.CharField("Условный дедлайн", max_length=1000, blank=True)
-    #uploaded_file = models.FileField(upload_to='uploads/', blank = True, verbose_name="Приложение к РЗ")
+    conditional_deadline = models.CharField("Условия/ограничения", max_length=1000, blank=True)
 
     version_diff = models.TextField(
         "Сравнение версий",
@@ -1675,64 +1709,40 @@ class WorkAssignment(models.Model):
     )
     control_date = models.DateField("Дата фиксации статуса", null=True, blank=True)
 
-   #def _build_name(self) -> str:
-    #    sep = " — "  # любой разделитель
-     #   technical_assignment_part = (self.technical_assignment.name if self.technical_assignment_id else "").strip()
-#
- #       # Нормализуем и режем вторую часть до 50 символов без троеточия
-  #      task_clean = " ".join((self.task or "").split())
-   #     # чтобы не переполнить name, сначала считаем доступную длину под вторую часть
-    #    max_len = self._meta.get_field('name').max_length
-     #   allowed_for_task = max(0, min(50, max_len - len(sep) - len(technical_assignment_part)))
-      #  task_part = Truncator(task_clean).chars(allowed_for_task, truncate='')
-
-       # return f"{technical_assignment_part}{sep}{task_part}" if task_part else technical_assignment_part"""
-
     def clean(self):
         super().clean()
-        if self.hard_deadline and self.target_deadline:
-            if self.hard_deadline < self.target_deadline:
-                raise ValidationError({
-                    "hard_deadline": _(
-                        "Абсолютный дедлайн не может быть раньше целевого."
-                    )
-                })
 
-        if self.time_window_end and self.target_deadline:
-            if self.time_window_end > self.target_deadline:
-                raise ValidationError({
-                    "time_window_end": _(
-                        "Конец временного окна не может быть позже целевого дедлайна."
-                    )
-                })
+        dates, date_errors = _normalize_model_dates(
+            self,
+            ("target_deadline", "hard_deadline", "time_window_start", "time_window_end"),
+        )
+        if date_errors:
+            raise ValidationError(date_errors)
 
-            def save(self, *args, **kwargs):
-                self.full_clean()
-                return super().save(*args, **kwargs)
-    class Meta:
-        verbose_name = 'Рабочее задание'
-        verbose_name_plural = 'Рабочие задания'
+        target = dates["target_deadline"]
+        hard = dates["hard_deadline"]
+        tw_start = dates["time_window_start"]
+        tw_end = dates["time_window_end"]
 
-    #def save(self, *args, **kwargs):
-     #   self.name = self._build_name()
-      #  super().save(*args, **kwargs)
+        if tw_start and tw_end and tw_end < tw_start:
+            raise ValidationError({
+                "time_window_end": "Дата «по» не может быть раньше даты «с».",
+            })
 
-    def clean(self):
-        super().clean()
-        # проверка окна
-        if self.time_window_start and self.time_window_end:
-            if self.time_window_end < self.time_window_start:
-                raise ValidationError({'time_window_end': 'Дата «по» не может быть раньше даты «с».'})
+        if target and tw_end and tw_end > target:
+            raise ValidationError({
+                "time_window_end": "Конец временного окна не может быть позже целевого срока.",
+            })
 
-    def clean(self):
-        super().clean()
-        if self.time_window_start and self.time_window_end and self.time_window_end < self.time_window_start:
-            raise ValidationError({'time_window_end': 'Дата «по» не может быть раньше даты «с».'})
-        if self.target_deadline and self.time_window_start and self.time_window_end:
-            if not (self.time_window_start <= self.target_deadline <= self.time_window_end):
-                raise ValidationError({'target_deadline': 'Целевой срок должен попадать в заданное окно.'})
-        if self.hard_deadline and self.target_deadline and self.target_deadline > self.hard_deadline:
-            raise ValidationError({'target_deadline': 'Целевой срок не может быть позже абсолютного дедлайна.'})
+        if target and tw_start and tw_end and not (tw_start <= target <= tw_end):
+            raise ValidationError({
+                "target_deadline": "Целевой срок должен попадать в заданное временное окно.",
+            })
+
+        if hard and target and hard < target:
+            raise ValidationError({
+                "hard_deadline": "Абсолютный дедлайн не может быть раньше целевого срока.",
+            })
 
     @property
     def effective_deadline(self):
@@ -1742,19 +1752,33 @@ class WorkAssignment(models.Model):
             return self.target_deadline
         if self.time_window_end:
             return self.time_window_end
-        return self.deadline
+        return None
 
     def is_active(self):
-        return self.control_status not in ('not_done',)
+        return self.control_status not in self.TERMINAL_STATUSES
+
+    def is_target_overdue(self, today=None):
+        if not self.is_active():
+            return False
+        if not self.target_deadline:
+            return False
+        today = today or timezone.localdate()
+        return today > self.target_deadline
+
+    def is_hard_overdue(self, today=None):
+        if not self.is_active():
+            return False
+        if not self.hard_deadline:
+            return False
+        today = today or timezone.localdate()
+        return today > self.hard_deadline
 
     def is_overdue(self, today=None):
         if not self.is_active():
             return False
-        d = self.effective_deadline
-        if not d:
-            return False
-        today = today or timezone.localdate()
-        return today > d
+        if self.is_target_overdue(today):
+            return True
+        return self.is_hard_overdue(today)
 
     def mark_result_on_close(self):
         if self.result:
@@ -1781,6 +1805,10 @@ class WorkAssignment(models.Model):
 
     def __str__(self):
         return self.name or "Без названия"
+
+    class Meta:
+        verbose_name = 'Рабочее задание'
+        verbose_name_plural = 'Рабочие задания'
 
 
 class WorkAssignmentSubtask(models.Model):
@@ -1844,7 +1872,7 @@ class WorkAssignmentSubtask(models.Model):
     result_description = models.TextField(
         max_length=5000, blank=True, null=True, verbose_name="Описание результата"
     )
-    target_deadline = models.DateField("Целевой срок выполнения", default=timezone.now)
+    target_deadline = models.DateField("Целевой срок выполнения", default=timezone.localdate)
     hard_deadline = models.DateField("Абсолютный дедлайн", null=True, blank=True)
     time_window_start = models.DateField("Временное окно: с", null=True, blank=True)
     time_window_end = models.DateField("Временное окно: по", null=True, blank=True)

--- a/blog/services.py
+++ b/blog/services.py
@@ -9,7 +9,6 @@ class WorkAssignmentService:
     def reschedule_deadline(
         assignment: WorkAssignment, *,
         new_target_deadline=None,
-        new_hard_deadline=None,
         new_time_window_start=None,
         new_time_window_end=None,
         reason: str = "",
@@ -34,10 +33,12 @@ class WorkAssignmentService:
         )
 
         # 3) применим только переданные поля
+        hard_reset = False
         if new_target_deadline is not None:
+            if new_target_deadline != old["target"] and old["hard"] is not None:
+                assignment.hard_deadline = None
+                hard_reset = True
             assignment.target_deadline = new_target_deadline
-        if new_hard_deadline is not None:
-            assignment.hard_deadline = new_hard_deadline
         if new_time_window_start is not None:
             assignment.time_window_start = new_time_window_start
         if new_time_window_end is not None:
@@ -75,6 +76,7 @@ class WorkAssignmentService:
             "date_of_change","last_editor"
         ])
 
+        assignment._hard_deadline_reset = hard_reset
         return assignment
 
 

--- a/shared_repository/models.py
+++ b/shared_repository/models.py
@@ -1329,12 +1329,6 @@ class EmployeeProfile(models.Model):
         verbose_name='Пользователь'
     )
     patronymic = models.CharField('Отчество', max_length=100, blank=True)
-    inn = models.CharField(
-        max_length=12,
-        blank=True,
-        null=True,
-        verbose_name='ИНН',
-    )
     phone = models.CharField('Телефон', max_length=20, blank=True)
     org_department = models.ForeignKey(
         'Department',

--- a/templates/admin/approvals/cabinet.html
+++ b/templates/admin/approvals/cabinet.html
@@ -105,6 +105,19 @@
     background:#417690; color:#fff; border-radius:999px;
     padding:1px 9px; font-size:11px; font-weight:700;
   }
+  details.cab-group { margin-bottom:10px; }
+  details.cab-group > summary {
+    cursor:pointer; user-select:none; list-style:none;
+    margin-bottom:0; padding-bottom:8px;
+  }
+  details.cab-group > summary::-webkit-details-marker { display:none; }
+  details.cab-group > summary::after {
+    content:"▸"; margin-left:auto; font-size:13px; opacity:.7;
+    transition:transform .15s;
+  }
+  details.cab-group[open] > summary::after { transform:rotate(90deg); }
+  details.cab-group > summary:hover { color:var(--body-fg,#9ec5d8); }
+  .cab-group-body { padding-top:12px; }
   .cab-group-sub {
     font-size:12px; font-weight:600; text-transform:none; letter-spacing:0;
     color:var(--body-quiet-color,#aaa); margin-left:auto;
@@ -120,19 +133,49 @@
   .cab-st-group {
     margin-bottom:18px; border:1px solid var(--hairline-color,#444);
     border-radius:12px; overflow:hidden;
-    border-left:4px solid #5c6bc0;
+    border-left:4px solid #417690;
   }
-  .cab-st-parent { padding:12px 16px; background:rgba(92,107,192,.12); }
+  .cab-st-parent { padding:12px 16px; background:rgba(65,118,144,.12); }
   .cab-st-parent-head { display:flex; align-items:center; gap:10px; flex-wrap:wrap; }
-  .cab-st-code { font-size:15px; font-weight:800; color:#5c6bc0; letter-spacing:.02em; }
+  .cab-st-code { font-size:15px; font-weight:800; color:var(--link-fg,#417690); letter-spacing:.02em; }
   .cab-st-pill {
-    background:#5c6bc0; color:#fff; border-radius:999px;
+    background:#417690; color:#fff; border-radius:999px;
     padding:2px 10px; font-size:11px; font-weight:700;
   }
   .cab-st-parent-task {
     margin-top:6px; font-size:12px; line-height:1.4;
     color:var(--body-quiet-color,#9a9a9a);
   }
+  .cab-st-parent-meta { margin-top:6px; font-size:12px; color:var(--body-quiet-color,#999); }
+  .cab-section { margin-bottom:8px; }
+  .cab-section + .cab-section { margin-top:22px; }
+  .cab-section > summary.cab-section-title {
+    font-size:13px; font-weight:800; letter-spacing:.03em;
+    color:var(--body-fg,#ddd); margin:6px 0 14px;
+    padding-bottom:6px; border-bottom:2px solid #417690;
+    display:flex; align-items:center; gap:8px;
+    cursor:pointer; user-select:none; list-style:none;
+  }
+  .cab-section > summary.cab-section-title::-webkit-details-marker { display:none; }
+  .cab-section > summary.cab-section-title::after {
+    content:"▾"; margin-left:auto; opacity:.7; font-size:12px; transition:transform .15s;
+  }
+  .cab-section:not([open]) > summary.cab-section-title::after { transform:rotate(-90deg); }
+  .cab-section-count {
+    background:#417690; color:#fff; border-radius:999px;
+    padding:1px 9px; font-size:11px; font-weight:700;
+  }
+  details.cab-subtasks > summary {
+    cursor:pointer; user-select:none; list-style:none;
+    padding:9px 16px; font-size:12px; font-weight:700; color:var(--link-fg,#417690);
+    display:flex; align-items:center; gap:6px;
+    border-top:1px dashed var(--hairline-color,#444);
+  }
+  details.cab-subtasks > summary::-webkit-details-marker { display:none; }
+  details.cab-subtasks > summary::after {
+    content:"▸"; margin-left:6px; opacity:.7; transition:transform .15s;
+  }
+  details.cab-subtasks[open] > summary::after { transform:rotate(90deg); }
   .cab-st-caption {
     font-size:10px; font-weight:700; letter-spacing:.06em; text-transform:uppercase;
     color:var(--body-quiet-color,#888); padding:10px 16px 4px;
@@ -320,25 +363,27 @@
   <div class="cab-panel" data-panel="assigned">
     {% regroup assigned_items by model_label as assigned_groups %}
     {% for group in assigned_groups %}
-    <div class="cab-group">
-      <div class="cab-group-head">
+    <details class="cab-group">
+      <summary class="cab-group-head">
         <span class="cab-group-icon" aria-hidden="true">📦</span>
         {{ group.grouper }}
         <span class="cab-group-count">{{ group.list|length }}</span>
-      </div>
-      {% for it in group.list %}
-      <div class="cab-card cab-card--compact">
-        <div class="cab-info">
-          <div class="title">{{ it.title }}</div>
+      </summary>
+      <div class="cab-group-body">
+        {% for it in group.list %}
+        <div class="cab-card cab-card--compact">
+          <div class="cab-info">
+            <div class="title">{{ it.title }}</div>
+          </div>
+          <div class="cab-actions">
+            {% if it.admin_url %}
+            <a class="btn btn-gray btn-sm" href="{{ it.admin_url }}">Открыть</a>
+            {% endif %}
+          </div>
         </div>
-        <div class="cab-actions">
-          {% if it.admin_url %}
-          <a class="btn btn-gray btn-sm" href="{{ it.admin_url }}">Открыть</a>
-          {% endif %}
-        </div>
+        {% endfor %}
       </div>
-      {% endfor %}
-    </div>
+    </details>
     {% empty %}
     <div class="cab-empty">Нет объектов, где вы — текущий ответственный.</div>
     {% endfor %}
@@ -348,13 +393,24 @@
     {% for wa in my_work %}
     <div class="cab-card">
       <div class="cab-info">
-        <div class="title">{{ wa.name|default:wa }}</div>
+        <div class="title">
+          {% if wa.wa_full_code %}{{ wa.wa_full_code }}{% else %}{{ wa.name|default:"Рабочее задание" }}{% endif %}
+        </div>
+        {% if wa.task %}<div class="issued-task">{{ wa.task }}</div>{% endif %}
         <div class="meta">
-          {% if wa.post %}{{ wa.post }} · {% endif %}
+          {% if wa.control_status == "on_time" %}<span class="pill pill-green">Выполнено в срок</span>
+          {% elif wa.control_status == "rescheduled" %}<span class="pill pill-orange">С переносом</span>
+          {% elif wa.control_status == "partial" %}<span class="pill pill-orange">Частично</span>
+          {% elif wa.control_status == "not_done" %}<span class="pill pill-gray">Не выполнено</span>
+          {% else %}<span class="pill pill-blue">В работе</span>{% endif %}
+          {% if wa.post %}{{ wa.post }}{% endif %}
+        </div>
+        <div class="meta">
           Срок:
-          <span {% if wa.target_deadline < today %}class="cab-overdue"{% endif %}>
-            {{ wa.target_deadline|date:"d.m.Y" }}{% if wa.target_deadline < today %} (просрочено){% endif %}
-          </span>
+          <strong {% if wa.target_deadline < today %}class="cab-overdue"{% endif %}>
+            {{ wa.target_deadline|date:"d.m.Y" }}
+          </strong>
+          {% if wa.target_deadline < today %} (просрочено){% endif %}
         </div>
       </div>
       <div class="cab-actions">
@@ -362,31 +418,29 @@
       </div>
     </div>
     {% empty %}
-    <div class="cab-empty">Нет активных заданий, назначенных вам.</div>
+    <div class="cab-empty">Нет активных задач, где вы исполнитель.</div>
     {% endfor %}
   </div>
 
   <div class="cab-panel" data-panel="subtasks">
+    {% regroup my_subtasks by work_assignment as subtask_groups %}
     {% for group in subtask_groups %}
     <div class="cab-st-group">
       <div class="cab-st-parent">
         <div class="cab-st-parent-head">
           <span class="cab-st-code">
-            📋 {% if group.wa %}{{ group.wa.wa_full_code|default:"Рабочее задание" }}{% else %}Без рабочего задания{% endif %}
+            📋 {{ group.grouper.wa_full_code|default:group.grouper.name|default:"Рабочее задание" }}
           </span>
-          <span class="cab-st-pill">Подзадач: {{ group.subtasks|length }}</span>
-          {% if group.wa %}
+          <span class="cab-st-pill">Мои подзадачи: {{ group.list|length }}</span>
           <a class="btn btn-ghost btn-sm" style="margin-left:auto;"
-             href="{% url 'admin:blog_workassignment_change' group.wa.pk %}">Открыть РЗ</a>
-          {% endif %}
+             href="{% url 'admin:blog_workassignment_change' group.grouper.pk %}">Открыть РЗ</a>
         </div>
-        {% if group.wa.task %}
-        <div class="cab-st-parent-task clamp2" title="{{ group.wa.task }}">{{ group.wa.task }}</div>
+        {% if group.grouper.task %}
+        <div class="cab-st-parent-task clamp2" title="{{ group.grouper.task }}">{{ group.grouper.task }}</div>
         {% endif %}
       </div>
-      <div class="cab-st-caption">Подзадачи ↓</div>
       <div class="cab-st-children">
-        {% for st in group.subtasks %}
+        {% for st in group.list %}
         <div class="cab-st-child">
           <div class="cab-info">
             <div class="task-text clamp2" title="{{ st.task }}">
@@ -408,7 +462,7 @@
       </div>
     </div>
     {% empty %}
-    <div class="cab-empty">Нет активных подзадач, назначенных вам.</div>
+    <div class="cab-empty">У вас нет активных подзадач.</div>
     {% endfor %}
   </div>
 

--- a/templates/admin/approvals/cabinet.html
+++ b/templates/admin/approvals/cabinet.html
@@ -11,7 +11,7 @@
     display:flex; flex-direction:column; gap:0;
   }
   .cab-nav-row {
-    display:grid; grid-template-columns:108px 1fr; gap:12px 16px;
+    display:grid; grid-template-columns:130px 1fr; gap:12px 26px;
     align-items:center; padding:10px 0;
   }
   .cab-nav-row + .cab-nav-row { border-top:1px solid rgba(121,174,200,.12); }
@@ -82,6 +82,7 @@
   .pill-gray { background:#9E9E9E; } .pill-orange { background:#FB8C00; }
   .pill-purple { background:#9C27B0; }
   .pill-type { background:#607D8B; }
+  .pill-amber { background:#FFA000; } .pill-cyan { background:#00ACC1; }
 
   .cab-actions { display:flex; gap:8px; flex-wrap:wrap; }
   .btn { padding:7px 15px; border-radius:6px; color:#fff; font-weight:600; font-size:13px; text-decoration:none; border:none; cursor:pointer; }
@@ -92,6 +93,70 @@
   .cab-wrap a.btn:link, .cab-wrap a.btn:visited { color:#fff; }
   .cab-wrap a.btn-ghost:link, .cab-wrap a.btn-ghost:visited { color:#417690; }
   .cab-wrap a.btn-ghost { border-color:#417690; }
+
+  /* Фильтр по статусам и секции внутри «Мои задачи» / «Выданные задачи» */
+  .cab-wfilter { display:flex; gap:6px; flex-wrap:wrap; margin-bottom:16px; }
+  .cab-wfilter button {
+    border:1px solid rgba(121,174,200,.45); background:transparent;
+    color:var(--body-fg); border-radius:999px; padding:5px 14px;
+    font-size:12px; font-weight:600; cursor:pointer;
+  }
+  .cab-wfilter button.active { background:#417690; color:#fff; border-color:#417690; }
+  .cab-wstatus-section { margin-bottom:14px; }
+  .cab-wstatus-head {
+    display:flex; align-items:center; gap:10px; margin:0; padding:10px 14px;
+    border-radius:9px; border:1px solid rgba(128,128,128,.20);
+    background:rgba(128,128,128,.10);
+    font-size:13px; font-weight:700; color:var(--body-fg);
+  }
+  details.cab-wstatus-section > summary.cab-wstatus-head {
+    cursor:pointer; user-select:none; list-style:none;
+    transition:background .12s;
+  }
+  details.cab-wstatus-section > summary.cab-wstatus-head:hover {
+    background:rgba(128,128,128,.18);
+  }
+  details.cab-wstatus-section > summary::-webkit-details-marker { display:none; }
+  .cab-wstatus-head .cab-group-count { font-size:11px; }
+  details.cab-wstatus-section > summary.cab-wstatus-head::after {
+    content:"▾"; margin-left:auto; font-size:12px; opacity:.6;
+    transition:transform .15s;
+  }
+  details.cab-wstatus-section:not([open]) > summary.cab-wstatus-head::after {
+    transform:rotate(-90deg);
+  }
+  details.cab-wstatus-section[open] > summary.cab-wstatus-head { margin-bottom:12px; }
+  .cab-wform { margin:0; display:inline; }
+  .cab-wa-btn {
+    display:inline-flex; align-items:center; gap:6px;
+    padding:7px 15px; border-radius:6px; font-size:13px; font-weight:600;
+    white-space:nowrap; font-family:inherit; text-decoration:none;
+    border:1px solid transparent; box-sizing:border-box;
+  }
+  button.cab-wa-btn { cursor:pointer; appearance:none; -webkit-appearance:none; }
+  a.cab-wa-btn:hover { text-decoration:none; }
+  .cab-wa-btn--amber {
+    color:#f57c00; background:rgba(255,160,0,.12);
+    border-color:rgba(255,160,0,.45);
+  }
+  .cab-wa-btn--amber:hover { background:rgba(255,160,0,.22); }
+  .cab-wa-btn--cyan {
+    color:#0097a7; background:rgba(0,172,193,.12);
+    border-color:rgba(0,172,193,.45);
+  }
+  .cab-wa-btn--cyan:hover { background:rgba(0,172,193,.22); }
+  .cab-wa-btn--green {
+    color:#2e7d32; background:rgba(76,175,80,.12);
+    border-color:rgba(76,175,80,.45);
+  }
+  .cab-wa-btn--green:hover { background:rgba(76,175,80,.22); }
+  .cab-wa-btn--outline {
+    color:#417690; background:transparent;
+    border-color:rgba(65,118,144,.55);
+  }
+  .cab-wa-btn--outline:hover { background:rgba(65,118,144,.10); }
+  .cab-wrap a.cab-wa-btn--outline:link,
+  .cab-wrap a.cab-wa-btn--outline:visited { color:#417690; }
 
   .cab-group { margin-bottom:24px; }
   .cab-group-head {
@@ -213,37 +278,32 @@
 
   <nav class="cab-nav" aria-label="Разделы личного кабинета">
     <div class="cab-nav-row">
-      <span class="cab-nav-label"><span class="cab-nav-label-icon">📑</span> Согласование</span>
+      <span class="cab-nav-label"><span class="cab-nav-label-icon">📑</span> Согласование/ознакомление</span>
       <div class="cab-tabs cab-tabs--3">
         <button type="button" class="cab-tab active" data-tab="sign">
           <span class="cab-tab-icon" aria-hidden="true">✍️</span>
-          <span class="cab-tab-label">Подпись</span>
+          <span class="cab-tab-label">Согласование документа (подпись)</span>
           {% if sign_tasks %}<span class="cab-badge">{{ sign_tasks|length }}</span>{% endif %}
         </button>
         <button type="button" class="cab-tab" data-tab="ack">
           <span class="cab-tab-icon" aria-hidden="true">👁️</span>
-          <span class="cab-tab-label">Ознакомление</span>
+          <span class="cab-tab-label">Ознакомление с документом (подпись)</span>
           {% if ack_tasks %}<span class="cab-badge">{{ ack_tasks|length }}</span>{% endif %}
         </button>
         <button type="button" class="cab-tab" data-tab="fix">
           <span class="cab-tab-icon" aria-hidden="true">✏️</span>
-          <span class="cab-tab-label">Доработка</span>
+          <span class="cab-tab-label">Доработка (по итогам согласования)</span>
           {% if fix_tasks %}<span class="cab-badge">{{ fix_tasks|length }}</span>{% endif %}
         </button>
       </div>
     </div>
     <div class="cab-nav-row">
-      <span class="cab-nav-label"><span class="cab-nav-label-icon">📋</span> Задания</span>
-      <div class="cab-tabs cab-tabs--4">
-        <button type="button" class="cab-tab" data-tab="assigned">
-          <span class="cab-tab-icon" aria-hidden="true">🎯</span>
-          <span class="cab-tab-label">Мне назначено (Текущий ответственный)</span>
-          {% if assigned_items %}<span class="cab-badge muted">{{ assigned_items|length }}</span>{% endif %}
-        </button>
+      <span class="cab-nav-label"><span class="cab-nav-label-icon">📋</span> Рабочие задания</span>
+      <div class="cab-tabs cab-tabs--3">
         <button type="button" class="cab-tab" data-tab="work">
           <span class="cab-tab-icon" aria-hidden="true">📥</span>
           <span class="cab-tab-label">Мои задачи</span>
-          {% if my_work %}<span class="cab-badge muted">{{ my_work|length }}</span>{% endif %}
+          {% if my_work_active_count %}<span class="cab-badge muted">{{ my_work_active_count }}</span>{% endif %}
         </button>
         <button type="button" class="cab-tab" data-tab="subtasks">
           <span class="cab-tab-icon" aria-hidden="true">🧩</span>
@@ -259,7 +319,12 @@
     </div>
     <div class="cab-nav-row">
       <span class="cab-nav-label"><span class="cab-nav-label-icon">📌</span> Прочее</span>
-      <div class="cab-tabs cab-tabs--2">
+      <div class="cab-tabs cab-tabs--3">
+        <button type="button" class="cab-tab" data-tab="assigned">
+          <span class="cab-tab-icon" aria-hidden="true">🎯</span>
+          <span class="cab-tab-label">Мне назначено (Текущий ответственный)</span>
+          {% if assigned_items %}<span class="cab-badge muted">{{ assigned_items|length }}</span>{% endif %}
+        </button>
         <button type="button" class="cab-tab" data-tab="docs">
           <span class="cab-tab-icon" aria-hidden="true">📄</span>
           <span class="cab-tab-label">Мои документы</span>
@@ -390,36 +455,67 @@
   </div>
 
   <div class="cab-panel" data-panel="work">
-    {% for wa in my_work %}
-    <div class="cab-card">
-      <div class="cab-info">
-        <div class="title">
-          {% if wa.wa_full_code %}{{ wa.wa_full_code }}{% else %}{{ wa.name|default:"Рабочее задание" }}{% endif %}
-        </div>
-        {% if wa.task %}<div class="issued-task">{{ wa.task }}</div>{% endif %}
-        <div class="meta">
-          {% if wa.control_status == "on_time" %}<span class="pill pill-green">Выполнено в срок</span>
-          {% elif wa.control_status == "rescheduled" %}<span class="pill pill-orange">С переносом</span>
-          {% elif wa.control_status == "partial" %}<span class="pill pill-orange">Частично</span>
-          {% elif wa.control_status == "not_done" %}<span class="pill pill-gray">Не выполнено</span>
-          {% else %}<span class="pill pill-blue">В работе</span>{% endif %}
-          {% if wa.post %}{{ wa.post }}{% endif %}
-        </div>
-        <div class="meta">
-          Срок:
-          <strong {% if wa.target_deadline < today %}class="cab-overdue"{% endif %}>
-            {{ wa.target_deadline|date:"d.m.Y" }}
-          </strong>
-          {% if wa.target_deadline < today %} (просрочено){% endif %}
-        </div>
-      </div>
-      <div class="cab-actions">
-        <a class="btn btn-gray" href="{% url 'admin:blog_workassignment_change' wa.pk %}">Открыть</a>
-      </div>
+    {% if my_work %}
+    <div class="cab-wfilter" data-wfilter-for="work">
+      <button type="button" class="active" data-wfilter="all">Все</button>
+      {% for g in my_work_groups %}{% if g.count %}
+      <button type="button" data-wfilter="{{ g.key }}">{{ g.label }} ({{ g.count }})</button>
+      {% endif %}{% endfor %}
     </div>
-    {% empty %}
-    <div class="cab-empty">Нет активных задач, где вы исполнитель.</div>
-    {% endfor %}
+    {% for g in my_work_groups %}{% if g.count %}
+    <details class="cab-wstatus-section" data-wgroup="{{ g.key }}">
+      <summary class="cab-wstatus-head">
+        <span class="pill {% if g.key == 'assigned' %}pill-amber{% elif g.key == 'in_progress' %}pill-blue{% elif g.key == 'review' %}pill-cyan{% else %}pill-green{% endif %}">{{ g.label }}</span>
+        <span class="cab-group-count">{{ g.count }}</span>
+      </summary>
+      {% for wa in g.items %}
+      <div class="cab-card">
+        <div class="cab-info">
+          <div class="title">
+            {% if wa.wa_full_code %}{{ wa.wa_full_code }}{% else %}{{ wa.name|default:"Рабочее задание" }}{% endif %}
+          </div>
+          {% if wa.task %}<div class="issued-task">{{ wa.task }}</div>{% endif %}
+          <div class="meta">
+            {% if wa.control_status == "assigned" %}<span class="pill pill-amber">Ожидает принятия</span>
+            {% elif wa.control_status == "review" %}<span class="pill pill-cyan">На проверке</span>
+            {% elif wa.control_status == "on_time" %}<span class="pill pill-green">Выполнено в срок</span>
+            {% elif wa.control_status == "rescheduled" %}<span class="pill pill-orange">С переносом</span>
+            {% elif wa.control_status == "partial" %}<span class="pill pill-orange">Частично</span>
+            {% elif wa.control_status == "not_done" %}<span class="pill pill-gray">Не выполнено</span>
+            {% else %}<span class="pill pill-blue">В работе</span>{% endif %}
+            {% if wa.post %}{{ wa.post }}{% endif %}
+          </div>
+          <div class="meta">
+            Срок:
+            {% if g.key == "done" %}
+              <strong>{{ wa.target_deadline|date:"d.m.Y" }}</strong>
+            {% else %}
+              <strong {% if wa.target_deadline < today %}class="cab-overdue"{% endif %}>{{ wa.target_deadline|date:"d.m.Y" }}</strong>
+              {% if wa.target_deadline < today %} (просрочено){% endif %}
+            {% endif %}
+          </div>
+        </div>
+        <div class="cab-actions">
+          {% if wa.control_status == "assigned" %}
+          <form method="post" class="cab-wform" action="{% url 'admin:blog_workassignment_acknowledge' wa.pk %}">
+            {% csrf_token %}<button type="submit" class="cab-wa-btn cab-wa-btn--amber">Принять в работу</button>
+          </form>
+          {% elif wa.control_status == "review" %}
+          <span class="cab-wa-btn cab-wa-btn--cyan">⏳ На проверке у автора</span>
+          {% elif wa.control_status == "in_progress" or not wa.control_status %}
+          <form method="post" class="cab-wform" action="{% url 'admin:blog_workassignment_submit_review' wa.pk %}">
+            {% csrf_token %}<button type="submit" class="cab-wa-btn cab-wa-btn--cyan">Сдать на проверку</button>
+          </form>
+          {% endif %}
+          <a class="btn btn-gray" href="{% url 'admin:blog_workassignment_change' wa.pk %}">Открыть</a>
+        </div>
+      </div>
+      {% endfor %}
+    </details>
+    {% endif %}{% endfor %}
+    {% else %}
+    <div class="cab-empty">Задач, где вы исполнитель, пока нет.</div>
+    {% endif %}
   </div>
 
   <div class="cab-panel" data-panel="subtasks">
@@ -467,47 +563,66 @@
   </div>
 
   <div class="cab-panel" data-panel="issued">
-    {% for wa in issued_work %}
-    <div class="cab-card">
-      <div class="cab-info">
-        <div class="title">
-          {% if wa.wa_full_code %}{{ wa.wa_full_code }}{% else %}{{ wa.name|default:"Рабочее задание" }}{% endif %}
-        </div>
-        {% if wa.task %}<div class="issued-task">{{ wa.task }}</div>{% endif %}
-        <div class="meta">
-          {% if wa.control_status == "on_time" %}<span class="pill pill-green">Выполнено в срок</span>
-          {% elif wa.control_status == "rescheduled" %}<span class="pill pill-orange">С переносом</span>
-          {% elif wa.control_status == "partial" %}<span class="pill pill-orange">Частично</span>
-          {% elif wa.control_status == "not_done" %}<span class="pill pill-gray">Не выполнено</span>
-          {% else %}<span class="pill pill-blue">В работе</span>{% endif %}
-          {% if wa.executor %}
-            Исполнитель: <strong>{{ wa.executor }}</strong>{% if wa.executor_id == wa.author_id %} (себе){% endif %}
-          {% endif %}
-          {% if wa.current_responsible_id != wa.executor_id %}
-            · Ответственный: <strong>{{ wa.current_responsible }}</strong>
-          {% endif %}
-          {% if wa.post %} · {{ wa.post }}{% endif %}
-        </div>
-        <div class="meta">
-          Срок:
-          <strong {% if not wa.control_status or wa.control_status == "in_progress" %}{% if wa.target_deadline < today %}class="cab-overdue"{% endif %}{% endif %}>
-            {{ wa.target_deadline|date:"d.m.Y" }}
-          </strong>
-          {% if not wa.control_status or wa.control_status == "in_progress" %}
-            {% if wa.target_deadline < today %} (просрочено){% endif %}
-          {% endif %}
-          · Создано: {{ wa.date_of_creation|date:"d.m.Y" }}
-          {% if wa.subtask_total %} · Подзадач: {{ wa.subtask_total }}{% endif %}
-          {% if wa.reschedule_count %} · Переносов: {{ wa.reschedule_count }}{% endif %}
-        </div>
-      </div>
-      <div class="cab-actions">
-        <a class="btn btn-gray" href="{% url 'admin:blog_workassignment_change' wa.pk %}">Открыть</a>
-      </div>
+    {% if issued_work %}
+    <div class="cab-wfilter" data-wfilter-for="issued">
+      <button type="button" class="active" data-wfilter="all">Все</button>
+      {% for g in issued_work_groups %}{% if g.count %}
+      <button type="button" data-wfilter="{{ g.key }}">{{ g.label }} ({{ g.count }})</button>
+      {% endif %}{% endfor %}
     </div>
-    {% empty %}
+    {% for g in issued_work_groups %}{% if g.count %}
+    <details class="cab-wstatus-section" data-wgroup="{{ g.key }}">
+      <summary class="cab-wstatus-head">
+        <span class="pill {% if g.key == 'assigned' %}pill-amber{% elif g.key == 'in_progress' %}pill-blue{% elif g.key == 'review' %}pill-cyan{% else %}pill-green{% endif %}">{{ g.label }}</span>
+        <span class="cab-group-count">{{ g.count }}</span>
+      </summary>
+      {% for wa in g.items %}
+      <div class="cab-card">
+        <div class="cab-info">
+          <div class="title">
+            {% if wa.wa_full_code %}{{ wa.wa_full_code }}{% else %}{{ wa.name|default:"Рабочее задание" }}{% endif %}
+          </div>
+          {% if wa.task %}<div class="issued-task">{{ wa.task }}</div>{% endif %}
+          <div class="meta">
+            {% if wa.control_status == "assigned" %}<span class="pill pill-amber">Ожидает принятия</span>
+            {% elif wa.control_status == "review" %}<span class="pill pill-cyan">На проверке</span>
+            {% elif wa.control_status == "on_time" %}<span class="pill pill-green">Выполнено в срок</span>
+            {% elif wa.control_status == "rescheduled" %}<span class="pill pill-orange">С переносом</span>
+            {% elif wa.control_status == "partial" %}<span class="pill pill-orange">Частично</span>
+            {% elif wa.control_status == "not_done" %}<span class="pill pill-gray">Не выполнено</span>
+            {% else %}<span class="pill pill-blue">В работе</span>{% endif %}
+            {% if wa.executor %}
+              Исполнитель: <strong>{{ wa.executor }}</strong>{% if wa.executor_id == wa.author_id %} (себе){% endif %}
+            {% endif %}
+            {% if wa.post %} · {{ wa.post }}{% endif %}
+          </div>
+          <div class="meta">
+            Срок:
+            {% if g.key == "done" %}
+              <strong>{{ wa.target_deadline|date:"d.m.Y" }}</strong>
+            {% else %}
+              <strong {% if wa.target_deadline < today %}class="cab-overdue"{% endif %}>{{ wa.target_deadline|date:"d.m.Y" }}</strong>
+              {% if wa.target_deadline < today %} (просрочено){% endif %}
+            {% endif %}
+            · Создано: {{ wa.date_of_creation|date:"d.m.Y" }}
+            {% if wa.subtask_total %} · Подзадач: {{ wa.subtask_total }}{% endif %}
+            {% if wa.reschedule_count %} · Переносов: {{ wa.reschedule_count }}{% endif %}
+          </div>
+        </div>
+        <div class="cab-actions">
+          {% if wa.control_status == "review" %}
+          <a class="cab-wa-btn cab-wa-btn--green" href="{% url 'admin:blog_workassignment_close' wa.pk %}">Проверить и закрыть</a>
+          <a class="cab-wa-btn cab-wa-btn--outline" href="{% url 'admin:blog_workassignment_return' wa.pk %}">Вернуть на доработку</a>
+          {% endif %}
+          <a class="btn btn-gray" href="{% url 'admin:blog_workassignment_change' wa.pk %}">Открыть</a>
+        </div>
+      </div>
+      {% endfor %}
+    </details>
+    {% endif %}{% endfor %}
+    {% else %}
     <div class="cab-empty">У вас пока нет выданных заданий.</div>
-    {% endfor %}
+    {% endif %}
   </div>
 
   <div class="cab-panel" data-panel="docs">
@@ -582,6 +697,27 @@
     try { saved = localStorage.getItem("cabinetTab"); } catch (e) {}
     var exists = saved && document.querySelector('.cab-panel[data-panel="' + saved + '"]');
     if (exists) activate(saved);
+  })();
+
+  // Фильтр задач по статусу внутри панелей «Мои задачи» / «Выданные задачи».
+  (function () {
+    document.querySelectorAll(".cab-wfilter").forEach(function (bar) {
+      var panel = bar.closest(".cab-panel");
+      if (!panel) return;
+      bar.querySelectorAll("button[data-wfilter]").forEach(function (btn) {
+        btn.addEventListener("click", function () {
+          var key = btn.dataset.wfilter;
+          bar.querySelectorAll("button").forEach(function (b) {
+            b.classList.toggle("active", b === btn);
+          });
+          panel.querySelectorAll(".cab-wstatus-section").forEach(function (sec) {
+            var show = (key === "all" || sec.dataset.wgroup === key);
+            sec.style.display = show ? "" : "none";
+            if (show && key !== "all" && sec.tagName === "DETAILS") sec.open = true;
+          });
+        });
+      });
+    });
   })();
 </script>
 {% endblock %}

--- a/templates/admin/blog/workassignment/change_form.html
+++ b/templates/admin/blog/workassignment/change_form.html
@@ -1,4 +1,18 @@
 {% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block submit_buttons_bottom %}
+<div class="submit-row">
+  <input type="submit" value="Сохранить и отправить исполнителю" class="default" name="_save">
+  {% if not original or not original.executor_id %}
+    <input type="submit" value="Сохранить черновик" name="_addanother">
+  {% endif %}
+  <input type="submit" value="Сохранить и продолжить редактирование" name="_continue">
+  {% if show_close %}
+    <a href="{% url opts|admin_urlname:'changelist' %}" class="closelink">{% translate 'Close' %}</a>
+  {% endif %}
+</div>
+{% endblock %}
 
 {% block object-tools-items %}
   {{ block.super }}
@@ -138,7 +152,7 @@
           ul.className = "messagelist";
           ul.id = "reschedule-save-first-msg";
           ul.innerHTML =
-            '<li class="warning">Сначала сохраните изменения («Сохранить» или «Сохранить и продолжить редактирование»), затем снова нажмите «Перенести срок».</li>';
+            '<li class="warning">Сначала сохраните изменения (любой кнопкой сохранения), затем снова нажмите «Перенести срок».</li>';
           var content = document.getElementById("content");
           if (content) {
             content.insertBefore(ul, content.firstChild);
@@ -178,22 +192,6 @@
 
       var li = link.closest("li");
       if (li) li.remove();
-    });
-
-    // Автозаполнение даты фиксации при смене статуса
-    document.addEventListener("DOMContentLoaded", function () {
-      var statusField = document.getElementById("id_control_status");
-      var dateField   = document.getElementById("id_control_date");
-      if (!statusField || !dateField) return;
-
-      statusField.addEventListener("change", function () {
-        if (!statusField.value) return;
-        var today = new Date();
-        var yyyy  = today.getFullYear();
-        var mm    = String(today.getMonth() + 1).padStart(2, "0");
-        var dd    = String(today.getDate()).padStart(2, "0");
-        dateField.value = dd + "." + mm + "." + yyyy;
-      });
     });
   </script>
 {% endblock %}

--- a/templates/admin/blog/workassignment/close.html
+++ b/templates/admin/blog/workassignment/close.html
@@ -1,0 +1,23 @@
+{% extends "admin/base_site.html" %}
+{% block content %}
+  <h1>Проверить и закрыть задачу: {{ original }}</h1>
+  <div class="module aligned">
+    {% if original.task %}<p style="margin:0 0 10px;color:var(--body-quiet-color,#666);">{{ original.task }}</p>{% endif %}
+    {% if rescheduled_note %}
+    <p style="margin:0 0 12px;padding:8px 12px;border-left:3px solid #FF9800;background:rgba(255,152,0,.12);">
+      У задачи были переносы срока ({{ original.reschedule_count }}). При выборе «Выполнено» статус будет
+      автоматически зафиксирован как «Выполнено с переносом сроков».
+    </p>
+    {% endif %}
+    <form method="post" novalidate>
+      {% csrf_token %}
+      <table>
+        {{ form.as_table }}
+      </table>
+      <div class="submit-row">
+        <input type="submit" class="default" value="Закрыть задачу">
+        <a href="{% url 'admin:approvals_cabinet' %}" class="button cancel-link">Отмена</a>
+      </div>
+    </form>
+  </div>
+{% endblock %}

--- a/templates/admin/blog/workassignment/reschedule.html
+++ b/templates/admin/blog/workassignment/reschedule.html
@@ -1,6 +1,14 @@
 {% extends "admin/base_site.html" %}
 {% block content %}
   <h1>Перенести срок: {{ original }}</h1>
+  {% if had_hard_deadline %}
+  <ul class="messagelist">
+    <li class="warning">
+      При переносе целевого срока абсолютный дедлайн будет сброшен.
+      Если он нужен, назначьте его заново в карточке рабочего задания после переноса.
+    </li>
+  </ul>
+  {% endif %}
   <div class="module aligned">
     <form method="post" novalidate>
       {% csrf_token %}
@@ -14,4 +22,3 @@
     </form>
   </div>
 {% endblock %}
-

--- a/templates/admin/blog/workassignment/return.html
+++ b/templates/admin/blog/workassignment/return.html
@@ -1,0 +1,20 @@
+{% extends "admin/base_site.html" %}
+{% block content %}
+  <h1>Вернуть задачу на доработку: {{ original }}</h1>
+  <div class="module aligned">
+    {% if original.task %}<p style="margin:0 0 10px;color:var(--body-quiet-color,#666);">{{ original.task }}</p>{% endif %}
+    <p style="margin:0 0 12px;color:var(--body-quiet-color,#666);">
+      Задача вернётся исполнителю в статус «В работе».
+    </p>
+    <form method="post" novalidate>
+      {% csrf_token %}
+      <table>
+        {{ form.as_table }}
+      </table>
+      <div class="submit-row">
+        <input type="submit" class="default" value="Вернуть на доработку">
+        <a href="{% url 'admin:approvals_cabinet' %}" class="button cancel-link">Отмена</a>
+      </div>
+    </form>
+  </div>
+{% endblock %}


### PR DESCRIPTION
Main work assignments in the cabinet now follow accept -> review-> close/return, with status grouping and filters. Added close/return forms, date validation, and standard admin date widgets; fixed the deadline-history inline and editable subtask status on the parent task. Subtasks stay manual (admin + simple cabinet list). Rescheduling clears absolute deadline when the target date changes.