### PR TITLE
Update-1.0053-from-05-08-2026-(WorkAssignment attachments/fields cleanup, cabinet UI tweaks, Django 5.1.11, root redirect)

### DIFF
--- a/approvals/admin.py
+++ b/approvals/admin.py
@@ -981,7 +981,7 @@ class ApprovalTaskAdmin(admin.ModelAdmin):
             .filter(author=user)
             .filter(published_filter)
             .annotate(subtask_total=Count("subtasks"))
-            .select_related("executor", "post", "current_responsible")
+            .select_related("executor", "post")
         )
         issued_active = list(issued_base.filter(active_filter).order_by("target_deadline"))
         issued_done = list(

--- a/blog/admin.py
+++ b/blog/admin.py
@@ -6,7 +6,7 @@ from django.shortcuts import redirect, render
 from django.urls import path, reverse
 from django.utils import timezone
 from datetime import timedelta
-from django.utils.html import escape, format_html
+from django.utils.html import escape, format_html, format_html_join
 from django.template.defaultfilters import linebreaksbr
 from django.utils.safestring import mark_safe
 import re
@@ -338,29 +338,6 @@ class AttachmentInline(GenericTabularInline):
     formset = RequiredFileGenericFormSet
     extra = 1
     fields = ("file",)
-
-
-class WorkAssignmentAttachmentInline(AttachmentInline):
-    verbose_name = "файл"
-    verbose_name_plural = "Вложения"
-
-    def _wa_locked(self, obj):
-        return obj is not None and obj.control_status in WorkAssignment.TERMINAL_STATUSES
-
-    def has_add_permission(self, request, obj=None):
-        if self._wa_locked(obj):
-            return False
-        return super().has_add_permission(request, obj)
-
-    def has_change_permission(self, request, obj=None):
-        if self._wa_locked(obj):
-            return False
-        return super().has_change_permission(request, obj)
-
-    def has_delete_permission(self, request, obj=None):
-        if self._wa_locked(obj):
-            return False
-        return super().has_delete_permission(request, obj)
 
 
 def _tp_docs_section_header(title: str):
@@ -4398,7 +4375,6 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
     search_fields = (
         'name',
         'author__username',
-        'current_responsible__username',
         'post__wa_code',
     )
     list_filter = ('control_status', WorkAssignmentDraftFilter, OverdueFilter)
@@ -4433,9 +4409,11 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         'version', 'version_diff_display',
         'deadline_version', 'reschedule_count',
         'control_status_display', 'control_date_display',
+        'task_attachments_display', 'result_attachments_display',
+        'result_description_display', 'comment_display',
     )
 
-    inlines = [DeadlineChangeInline, WorkAssignmentSubtaskInline, WorkAssignmentAttachmentInline]
+    inlines = [DeadlineChangeInline, WorkAssignmentSubtaskInline]
 
     fieldsets = (
         ('Основная информация', {
@@ -4443,6 +4421,7 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 'name', 'executor', 'category', 'post',
                 'is_urgent',
                 'task', 'acceptance_criteria',
+                'task_attachments_display', 'attachments',
             )
         }),
         ('Сроки (изменять через «Перенести срок»)', {
@@ -4454,11 +4433,15 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
             )
         }),
         ('Статус выполнения / Результат', {
-            'fields': ('control_status_display', 'control_date_display', 'result_description', 'comment')
+            'fields': (
+                'control_status_display', 'control_date_display',
+                'result_description_display', 'comment_display',
+                'result_attachments_display',
+            )
         }),
         ('Системные данные', {
             'fields': (
-                'author', 'last_editor', 'current_responsible',
+                'author', 'last_editor',
                 'version', 'version_diff_display',
                 'date_of_creation', 'date_of_change',
                 'deadline_version', 'reschedule_count',
@@ -4471,6 +4454,7 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         for name in (
             'control_status', 'control_date', 'route',
             'reschedule_request_reason', 'reschedule_request_date',
+            'result_description', 'comment',
         ):
             if name not in excl:
                 excl.append(name)
@@ -4485,8 +4469,6 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
             ):
                 if name not in fields:
                     fields.append(name)
-            if request.user.id != obj.author_id and "comment" not in fields:
-                fields.append("comment")
             if request.user.id != obj.author_id and "is_urgent" not in fields:
                 fields.append("is_urgent")
         return fields
@@ -4611,14 +4593,12 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 obj.executor = None
                 obj.control_status = None
                 obj.control_date = None
-                obj.current_responsible = user
             else:
                 if not old_status and obj.executor_id:
                     obj.control_status = WorkAssignment.STATUS_ASSIGNED
                     obj.control_date = timezone.now()
                 elif obj.control_status and obj.control_status != old_status:
                     obj.control_date = timezone.now()
-                obj.current_responsible = obj.executor
         else:
             obj.author = user
             obj.last_editor = user
@@ -4626,12 +4606,10 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 obj.executor = None
                 obj.control_status = None
                 obj.control_date = None
-                obj.current_responsible = user
             else:
                 if not obj.control_status:
                     obj.control_status = WorkAssignment.STATUS_ASSIGNED
                     obj.control_date = timezone.now()
-                obj.current_responsible = obj.executor or user
 
         if obj.post_id:
             from .helpers import assign_wa_code_to_post, next_wa_number_for_post
@@ -4640,6 +4618,9 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 obj.wa_number = next_wa_number_for_post(obj.post, exclude_pk=obj.pk)
 
         super().save_model(request, obj, form, change)
+
+        for uploaded in form.cleaned_data.get("attachments") or []:
+            Attachment.objects.create(content_object=obj, file=uploaded, kind="")
 
         if (
             not is_draft
@@ -4808,6 +4789,40 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         ct = ContentType.objects.get_for_model(WorkAssignment)
         return Attachment.objects.filter(content_type=ct, object_id=obj.pk).exclude(kind="result")
 
+    @staticmethod
+    def _attachments_links(files):
+        if not files:
+            return "—"
+        return format_html_join(
+            ", ",
+            '<a href="{}" target="_blank">{}</a>',
+            ((a.file.url, a.file.name.rsplit("/", 1)[-1]) for a in files),
+        )
+
+    @admin.display(description="Уже загруженные файлы")
+    def task_attachments_display(self, obj):
+        if obj is None or not obj.pk:
+            return "—"
+        return self._attachments_links(self._wa_task_attachments(obj))
+
+    @admin.display(description="Загруженные файлы к результату")
+    def result_attachments_display(self, obj):
+        if obj is None or not obj.pk:
+            return "—"
+        return self._attachments_links(self._wa_result_attachments(obj))
+
+    @admin.display(description="Описание результата")
+    def result_description_display(self, obj):
+        if obj is None or not obj.result_description:
+            return "—"
+        return linebreaksbr(obj.result_description)
+
+    @admin.display(description="Комментарий автора")
+    def comment_display(self, obj):
+        if obj is None or not obj.comment:
+            return "—"
+        return linebreaksbr(obj.comment)
+
     def _notify_wa(self, recipient, title, text, obj):
         if not recipient:
             return
@@ -4835,10 +4850,9 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
             return back
         obj.control_status = WorkAssignment.STATUS_IN_PROGRESS
         obj.control_date = timezone.now()
-        obj.current_responsible = obj.executor
         obj.last_editor = request.user
         obj.save(update_fields=[
-            "control_status", "control_date", "current_responsible", "last_editor", "date_of_change",
+            "control_status", "control_date", "last_editor", "date_of_change",
         ])
         self._notify_wa(
             obj.author,
@@ -4892,12 +4906,11 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 self._append_text(obj, "result_description", form.cleaned_data["result_description"])
                 obj.control_status = WorkAssignment.STATUS_REVIEW
                 obj.control_date = timezone.now()
-                obj.current_responsible = obj.author
                 obj.last_editor = request.user
                 obj.returned_for_rework = False
                 obj.save(update_fields=[
                     "result_description", "control_status", "control_date",
-                    "current_responsible", "last_editor", "date_of_change",
+                    "last_editor", "date_of_change",
                     "returned_for_rework",
                 ])
                 for uploaded in form.cleaned_data.get("file") or []:
@@ -4967,11 +4980,10 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 obj.control_status = status
                 obj.control_date = timezone.now()
                 obj.result = self._RESULT_TEXT.get(status)
-                obj.current_responsible = obj.author
                 obj.last_editor = request.user
                 fields = [
                     "control_status", "control_date", "result",
-                    "current_responsible", "last_editor", "date_of_change",
+                    "last_editor", "date_of_change",
                 ]
                 if comment:
                     self._append_comment(obj, comment, label=self._RESULT_TEXT.get(status))
@@ -5022,11 +5034,10 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 comment = form.cleaned_data.get("comment", "").strip()
                 obj.control_status = WorkAssignment.STATUS_IN_PROGRESS
                 obj.control_date = timezone.now()
-                obj.current_responsible = obj.executor
                 obj.last_editor = request.user
                 obj.returned_for_rework = True
                 fields = [
-                    "control_status", "control_date", "current_responsible", "last_editor", "date_of_change",
+                    "control_status", "control_date", "last_editor", "date_of_change",
                     "returned_for_rework",
                 ]
                 if comment:
@@ -5092,12 +5103,11 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                         assignment.control_status = WorkAssignment.STATUS_IN_PROGRESS
                         assignment.reschedule_request_reason = ""
                         assignment.reschedule_request_date = None
-                        assignment.current_responsible = assignment.executor
                         assignment.control_date = timezone.now()
                         assignment.last_editor = request.user
                         assignment.save(update_fields=[
                             "control_status", "reschedule_request_reason", "reschedule_request_date",
-                            "current_responsible", "control_date", "last_editor", "date_of_change",
+                            "control_date", "last_editor", "date_of_change",
                         ])
                         self._notify_wa(
                             assignment.executor,
@@ -5150,12 +5160,11 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
                 obj.control_status = WorkAssignment.STATUS_RESCHEDULE_PENDING
                 obj.reschedule_request_reason = form.cleaned_data["reason"]
                 obj.reschedule_request_date = form.cleaned_data["desired_date"]
-                obj.current_responsible = obj.author
                 obj.control_date = timezone.now()
                 obj.last_editor = request.user
                 obj.save(update_fields=[
                     "control_status", "reschedule_request_reason", "reschedule_request_date",
-                    "current_responsible", "control_date", "last_editor", "date_of_change",
+                    "control_date", "last_editor", "date_of_change",
                 ])
                 self._notify_wa(
                     obj.author,
@@ -5194,12 +5203,11 @@ class WorkAssignmentAdmin(admin.ModelAdmin):
         obj.control_status = WorkAssignment.STATUS_IN_PROGRESS
         obj.reschedule_request_reason = ""
         obj.reschedule_request_date = None
-        obj.current_responsible = obj.executor
         obj.control_date = timezone.now()
         obj.last_editor = request.user
         obj.save(update_fields=[
             "control_status", "reschedule_request_reason", "reschedule_request_date",
-            "current_responsible", "control_date", "last_editor", "date_of_change",
+            "control_date", "last_editor", "date_of_change",
         ])
         self._notify_wa(
             obj.executor,

--- a/blog/admin_forms.py
+++ b/blog/admin_forms.py
@@ -4,11 +4,32 @@ from django.contrib.admin.widgets import AdminDateWidget
 from .models import WorkAssignment, _as_date, _INVALID_DATE_MSG
 
 
+class MultipleFileInput(forms.ClearableFileInput):
+    allow_multiple_selected = True
+
+
+class MultipleFileField(forms.FileField):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", MultipleFileInput())
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data, initial=None):
+        single_file_clean = super().clean
+        if isinstance(data, (list, tuple)):
+            return [single_file_clean(d, initial) for d in data]
+        return single_file_clean(data, initial)
+
+
 class WorkAssignmentAdminForm(forms.ModelForm):
     requires_hard_deadline = forms.BooleanField(
         required=False,
         initial=False,
         label="Требуется установить дед-лайн?",
+    )
+    attachments = MultipleFileField(
+        required=False,
+        label="Вложения (к заданию)",
+        help_text="Можно выбрать сразу несколько файлов.",
     )
 
     class Meta:
@@ -176,25 +197,9 @@ class WorkAssignmentRescheduleRequestForm(forms.Form):
     )
 
 
-class MultipleFileInput(forms.ClearableFileInput):
-    allow_multiple_selected = True
-
-
-class MultipleFileField(forms.FileField):
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault("widget", MultipleFileInput())
-        super().__init__(*args, **kwargs)
-
-    def clean(self, data, initial=None):
-        single_file_clean = super().clean
-        if isinstance(data, (list, tuple)):
-            return [single_file_clean(d, initial) for d in data]
-        return single_file_clean(data, initial)
-
-
 class WorkAssignmentSubmitReviewForm(forms.Form):
     result_description = forms.CharField(
         label="Описание результата",
         widget=forms.Textarea(attrs={"rows": 4, "cols": 60, "class": "vLargeTextField"}),
     )
-    file = MultipleFileField(required=False, label="Файлы")
+    file = MultipleFileField(required=False, label="Вложения (приложенные к результату)")

--- a/blog/apps.py
+++ b/blog/apps.py
@@ -70,8 +70,32 @@ class BlogConfig(AppConfig):
 
     def ready(self):
         from django.contrib import admin
+        from django.contrib.admin.options import BaseModelAdmin
+        from django.contrib.auth import get_user_model
+        from django.core.exceptions import ValidationError
 
         post_migrate.connect(_backfill_wa_codes, sender=self)
+
+        #выбрать неактивного пользователя нельзя -
+        # при сохранении формы падает ошибка валидации.
+        User = get_user_model()
+        _orig_formfield_for_foreignkey = BaseModelAdmin.formfield_for_foreignkey
+
+        def formfield_for_foreignkey(self, db_field, request, **kwargs):
+            field = _orig_formfield_for_foreignkey(self, db_field, request, **kwargs)
+            if field is not None and db_field.related_model is User:
+                orig_clean = field.clean
+
+                def clean(value, _orig_clean=orig_clean):
+                    user = _orig_clean(value)
+                    if user is not None and not user.is_active:
+                        raise ValidationError("Этот пользователь неактивен, его нельзя выбрать.")
+                    return user
+
+                field.clean = clean
+            return field
+
+        BaseModelAdmin.formfield_for_foreignkey = formfield_for_foreignkey
 
         site = admin.site
         _orig_get_app_list = site.get_app_list

--- a/blog/models.py
+++ b/blog/models.py
@@ -1652,7 +1652,7 @@ class WorkAssignment(models.Model):
     ACTIVE_STATUSES = ('assigned', 'in_progress', 'review', 'reschedule_pending')
     TERMINAL_STATUSES = ('on_time', 'rescheduled', 'partial', 'not_done')
 
-    name = models.CharField(max_length=100, unique=True, blank=True, null=True, verbose_name="Наименование")
+    name = models.CharField(max_length=100, blank=True, null=True, verbose_name="Наименование")
     wa_number = models.PositiveIntegerField(
         null=True,
         blank=True,
@@ -1671,11 +1671,6 @@ class WorkAssignment(models.Model):
         verbose_name="Последний редактор"
     )
     date_of_change = models.DateTimeField(auto_now=True, verbose_name="Дата и время последнего изменения")
-    current_responsible = models.ForeignKey(
-        User, on_delete=models.CASCADE,
-        related_name="responsible_workassignments",
-        verbose_name="Текущий ответственный"
-    )
     version = models.CharField(max_length=3, blank=True, null=True, verbose_name="Версия")
     task = models.TextField(
         verbose_name="Задача",

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -26,6 +26,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth import login
 from django.conf import settings
 from django.conf.urls.static import static
+from django.views.generic.base import RedirectView
 
 def register(request):
     if request.method == 'POST':
@@ -39,6 +40,7 @@ def register(request):
     return render(request, 'registration/register.html', {'form': form})
 
 urlpatterns = [
+    path('', RedirectView.as_view(url='/admin/', permanent=False)),
     path(
         "crm/api/decision-makers-by-customer/",
         decision_makers_by_customer_json,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.1.2
+Django==5.1.11
 weasyprint==68.1
 xhtml2pdf==0.2.17
 asn1crypto==1.5.1

--- a/templates/admin/approvals/cabinet.html
+++ b/templates/admin/approvals/cabinet.html
@@ -77,6 +77,7 @@
   .cab-card .title { font-size:15px; font-weight:700; }
   .cab-card .subtitle { font-size:13px; color:var(--body-quiet-color,#aaa); margin-top:2px; }
   .cab-card .meta { font-size:12px; color:var(--body-quiet-color,#999); margin-top:6px; display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+  .meta-label { font-weight:600; color:var(--body-fg); }
   .cab-card .note { font-size:12px; margin-top:6px; padding:6px 10px; border-radius:6px; background:rgba(229,57,53,.10); }
   .cab-card .note--orange { background:rgba(244,151,142,.16); }
   .cab-archive-note {
@@ -578,7 +579,7 @@
           <div class="title">
             {% if wa.wa_full_code %}{{ wa.wa_full_code }}{% else %}{{ wa.name|default:"Рабочее задание" }}{% endif %}
           </div>
-          {% if wa.task %}<div class="issued-task">Задача - {{ wa.task }}</div>{% endif %}
+          {% if wa.task %}<div class="issued-task"><span class="meta-label">Задача</span> - {{ wa.task }}</div>{% endif %}
           <div class="meta">
             {% if wa.control_status == "assigned" %}<span class="pill pill-amber">Ожидает принятия</span>
             {% elif wa.control_status == "review" %}<span class="pill pill-cyan">На проверке</span>
@@ -591,11 +592,14 @@
             {% if wa.returned_for_rework and wa.control_status == "in_progress" %}<span class="pill pill-peach">Возвращена на доработку</span>{% endif %}
             {% if wa.is_urgent %}<span class="pill pill-urgent">🔥 Срочно</span>{% endif %}
           </div>
+          {% if wa.acceptance_criteria and wa.acceptance_criteria != "---" %}
+          <div class="meta"><span class="meta-label">Критерий выполнения:</span> {{ wa.acceptance_criteria }}</div>
+          {% endif %}
           {% if wa.post %}
-          <div class="meta">Связанная разработка/проект - {{ wa.post }}</div>
+          <div class="meta"><span class="meta-label">Связанная разработка/проект</span> - {{ wa.post }}</div>
           {% endif %}
           <div class="meta">
-            Целевой срок выполнения:
+            <span class="meta-label">Целевой срок выполнения:</span>
             {% if g.key == "done" %}
               <strong>{{ wa.target_deadline|date:"d.m.Y" }}</strong>
             {% else %}
@@ -607,7 +611,7 @@
           {% endif %}
           {% if wa.wa_attachments %}
           <div class="meta">
-            Файлы, приложенные к заданию:
+            <span class="meta-label">Файлы, приложенные к заданию:</span>
             {% for a in wa.wa_attachments %}<a href="{{ a.file.url }}" target="_blank">{{ a.file.name|cut:"attachments/" }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
           </div>
           {% endif %}
@@ -615,7 +619,7 @@
           <div class="note note--orange">Комментарий автора: {{ wa.comment|linebreaksbr }}</div>
           {% endif %}
           {% if wa.author %}
-          <div class="meta">Автор: <strong><a href="{% url 'admin:approvals_user_profile' wa.author_id %}">{{ wa.author }}</a></strong></div>
+          <div class="meta"><span class="meta-label">Автор:</span> <strong><a href="{% url 'admin:approvals_user_profile' wa.author_id %}">{{ wa.author }}</a></strong></div>
           {% endif %}
         </div>
         <div class="cab-actions cab-actions--col">

--- a/templates/admin/blog/workassignment/change_form.html
+++ b/templates/admin/blog/workassignment/change_form.html
@@ -132,6 +132,58 @@
     })();
 
     document.addEventListener("DOMContentLoaded", function () {
+      // Вложения к заданию — тот же приём «+ добавить ещё файл», что и на
+      // страницах «Сдать на проверку»/«Вернуть на доработку»: несколько
+      // однофайловых input'ов с одинаковым name, вместо системного
+      // мультивыбора в одном input[multiple]. Кнопка — блочная, отдельной
+      // строкой под полями, не сбоку.
+      var input = document.getElementById("id_attachments");
+      if (input) {
+        var fieldName = input.name;
+        input.removeAttribute("multiple");
+        var list = document.createElement("div");
+        input.parentNode.insertBefore(list, input);
+
+        function addRow(existingInput) {
+          var row = document.createElement("div");
+          row.style.marginBottom = "6px";
+          var fileInput = existingInput || document.createElement("input");
+          if (!existingInput) {
+            fileInput.type = "file";
+            fileInput.name = fieldName;
+          }
+          row.appendChild(fileInput);
+          if (!existingInput) {
+            var removeBtn = document.createElement("a");
+            removeBtn.href = "#";
+            removeBtn.className = "deletelink";
+            removeBtn.style.marginLeft = "10px";
+            removeBtn.addEventListener("click", function (e) {
+              e.preventDefault();
+              row.remove();
+            });
+            row.appendChild(removeBtn);
+          }
+          list.appendChild(row);
+        }
+
+        addRow(input);
+
+        var addBtn = document.createElement("a");
+        addBtn.href = "#";
+        addBtn.className = "addlink";
+        addBtn.style.display = "block";
+        addBtn.style.marginTop = "4px";
+        addBtn.textContent = "Добавить ещё файл";
+        addBtn.addEventListener("click", function (e) {
+          e.preventDefault();
+          addRow();
+        });
+        list.after(addBtn);
+      }
+    });
+
+    document.addEventListener("DOMContentLoaded", function () {
       var form =
         document.querySelector("#workassignment_form") ||
         document.querySelector("#content-main form");


### PR DESCRIPTION
WorkAssignment attachments split into task/result with proper upload+display fields; result description and comment made read-only, auto-filled only; unused current_responsible field removed; task names no longer unique; Django bumped to 5.1.11 (fixes form headers); cabinet shows acceptance criteria with bolder labels; site root now redirects to /admin/.